### PR TITLE
Add openjdk role

### DIFF
--- a/logstash/defaults/main.yml
+++ b/logstash/defaults/main.yml
@@ -45,6 +45,8 @@ logstash_output_elasticsearch_hosts:
 logstash_output_elasticsearch_user: ""
 logstash_output_elasticsearch_password: ""
 
+logstash_restart: no
+
 logstash_cleanup_script: "remove_old_indices.py"
 logstash_cleanup: no
 logstash_remove_older_than: 30

--- a/logstash/tasks/main.yml
+++ b/logstash/tasks/main.yml
@@ -66,4 +66,10 @@
   service: name=logstash state=started
   tags: ['logstash', 'logstash:configuration']
 
+- name: Trigger handler to restart logstash
+  command: "/bin/true"
+  notify: restart logstash
+  when: logstash_restart
+  tags: ['logstash', 'logstash:configuration']
+
 - include: curator.yml

--- a/openjdk/defaults/main.yml
+++ b/openjdk/defaults/main.yml
@@ -1,0 +1,5 @@
+---
+
+openjdk_package: "openjdk-8-jdk"
+openjdk_profile: "openjdk.sh"
+openjdk_java_home: "/usr/lib/jvm/java-1.8.0-openjdk-amd64"

--- a/openjdk/tasks/main.yml
+++ b/openjdk/tasks/main.yml
@@ -1,0 +1,11 @@
+---
+
+- name: Install openjdk
+  apt: name="{{ openjdk_package }}" state=present update_cache=yes
+  tags: ['openjdk', 'openjdk:install']
+
+- name: Set JAVA_HOME environment variable on shell startup
+  template: >
+    src="{{ openjdk_profile }}" dest="/etc/profile.d/{{ openjdk_profile | basename }}"
+    owner=root group=root mode=0755
+  tags: ['openjdk', 'openjdk:configuration']

--- a/openjdk/templates/openjdk.sh
+++ b/openjdk/templates/openjdk.sh
@@ -1,0 +1,2 @@
+export JAVA_HOME="{{ openjdk_java_home }}"
+export PATH=$JAVA_HOME/bin:$PATH


### PR DESCRIPTION
Logstash requires Java to run. The `openjdk` role installs OpenJDK 8 and sets the `JAVA_HOME` environment variable.