### PR TITLE
[WIP] Add nginx role

### DIFF
--- a/nginx/defaults/main.yml
+++ b/nginx/defaults/main.yml
@@ -1,0 +1,23 @@
+---
+
+nginx_repositories: 
+  - "deb http://nginx.org/packages/ubuntu/ {{ ansible_distribution_release }} nginx"
+  - "deb-src http://nginx.org/packages/ubuntu/ {{ ansible_distribution_release }} nginx"
+nginx_apt_key_url: "https://nginx.org/keys/nginx_signing.key"
+
+nginx_tls: yes
+nginx_tls_private_key: ""
+nginx_tls_private_key_dest: "/etc/ssl/private"
+nginx_tls_cert: ""
+nginx_tls_cert_dest: "/etc/ssl/certs"
+nginx_dhparams_dir: "/etc/ssl/private"
+nginx_dhparams_filename: "dhparams.pem"
+
+nginx_config_dir: "/etc/nginx"
+nginx_configs: []
+nginx_sites_available_dir: "{{ nginx_config_dir }}/sites-available"
+nginx_sites_available: []
+nginx_sites_enabled_dir: "{{ nginx_config_dir }}/sites-enabled"
+nginx_sites_enabled: []
+
+nginx_restart: no

--- a/nginx/handlers/main.yml
+++ b/nginx/handlers/main.yml
@@ -1,0 +1,7 @@
+---
+
+- name: restart nginx
+  service: name=nginx state=restarted
+
+- name: reload nginx
+  service: name=nginx state=reloaded

--- a/nginx/tasks/main.yml
+++ b/nginx/tasks/main.yml
@@ -1,0 +1,92 @@
+---
+
+- name: Add nginx repo
+  apt_repository: repo="{{ item }}" update_cache=yes
+  with_items: nginx_repositories
+  tags: ['nginx', 'nginx:install']
+
+- name: Add nginx repository key
+  apt_key: url="{{ nginx_apt_key_url }}"
+  tags: ['nginx', 'nginx:install']
+
+- name: Install nginx
+  apt: name=nginx state=present update_cache=yes
+  tags: ['nginx', 'nginx:install']
+
+- name: Update OpenSSL to latest version
+  apt: name=openssl state=latest
+  when: nginx_tls
+  tags: ['nginx', 'nginx:configuration']
+
+- name: Create Diffie-Hellman parameters to prevent weak key exchange
+  command: >
+    openssl dhparam -out {{ nginx_dhparams_filename }} 2048
+    chdir={{ nginx_dhparams_dir }}
+    creates={{ nginx_dhparams_dir }}/{{ nginx_dhparams_filename }}
+  when: nginx_tls
+  tags: ['nginx', 'nginx:configuration']
+
+- name: Restrict permissions of DH parameters file
+  file: >
+    path="{{ nginx_dhparams_dir }}/{{ nginx_dhparams_filename }}"
+    owner=root group=root mode=0600
+  when: nginx_tls
+  tags: ['nginx', 'nginx:configuration']
+
+- name: Copy TLS private key
+  copy: >
+    content="{{ nginx_tls_private_key }}"
+    dest="{{ nginx_tls_private_key_dest  }}"
+    owner=root
+    mode=0600
+  notify: reload nginx
+  when: nginx_tls and nginx_tls_private_key != ""
+  tags: ['nginx', 'nginx:configuration']
+
+- name: Copy TLS certificate
+  copy: >
+    content="{{ nginx_tls_cert }}"
+    dest="{{ nginx_tls_cert_dest }}"
+    owner=root
+    mode=0600
+  notify: reload nginx
+  when: nginx_tls and nginx_tls_cert != ""
+  tags: ['nginx', 'nginx:configuration']
+
+- name: Copy nginx configuration files
+  template: src="{{ item }}" dest="{{ nginx_config_dir }}/{{ item | basename }}"
+  with_items: nginx_configs
+  notify: restart nginx
+  tags: ['nginx', 'nginx:configuration']
+
+- name: Create sites-available directory
+  file: path="{{ nginx_sites_available_dir }}" state=directory
+  tags: ['nginx', 'nginx:configuration']
+
+- name: Copy configuration files for available sites
+  template: src="{{ item }}" dest="{{ nginx_sites_available_dir }}/{{ item | basename }}"
+  with_items: nginx_sites_available
+  notify: reload nginx
+  tags: ['nginx', 'nginx:configuration']
+
+- name: Create sites-enabled directory
+  file: path="{{ nginx_sites_enabled_dir }}" state=directory
+  tags: ['nginx', 'nginx:configuration']
+
+- name: Remove links for enabled sites
+  file: path="{{ nginx_sites_enabled_dir }}/*" state=absent
+  tags: ['nginx', 'nginx:configuration']
+
+- name: Enable sites
+  file: >
+    src="{{ nginx_sites_available_dir }}/{{ item | basename }}"
+    dest="{{ nginx_sites_enabled_dir }}/{{ item | basename }}"
+    state=link
+  with_items: nginx_sites_enabled
+  tags: ['nginx', 'nginx:configuration']
+
+- name: Trigger handler to restart nginx
+  command: "/bin/true"
+  notify: restart nginx
+  when: nginx_restart
+  tags: ['nginx', 'nginx:configuration']


### PR DESCRIPTION
This PR adds a generalized nginx role. Adapted from the [wharf nginx role](https://github.com/appsembler/wharf/tree/develop/deploy/roles).

Useful settings:
- `nginx_sites_available` -- A list of local paths to sites-available configuration files. These are copied to the directory specified by `nginx_sites_available_dir`.
- `nginx_sites_enabled` -- A list of sites to be enabled. For each item, a soft link is created from `nginx_sites_enabled_dir` to the corresponding configuration file in `nginx_sites_available_dir`.

**TODO:**
- Add a default nginx.conf
- Add variable for extra configs (normally stored in `/etc/nginx/conf.d/`)
- Add default TLS settings (version, ciphers)
