### PR TITLE
Remove workaround for bug in Ansible 2.0

### DIFF
--- a/consul_template/tasks/main.yml
+++ b/consul_template/tasks/main.yml
@@ -1,9 +1,7 @@
 ---
 
-# Workaround for bug in Ansible 2.0. Use `docker_image` module for Ansible 2.1
 - name: Pull consul-template image
-  #docker_image: name="{{ consul_template_image }}" tag="{{ consul_template_image_tag }}" state=present
-  shell: docker pull {{ consul_template_image }}:{{ consul_template_image_tag }}
+  docker_image: name="{{ consul_template_image }}" tag="{{ consul_template_image_tag }}" state=present
   tags: ['consul_template', 'consul_template:install']
 
 - name: Copy systemd service file


### PR DESCRIPTION
This PR removes the shell-out to `docker pull` and uses the `docker_image` module instead. A [bug](https://github.com/ansible/ansible-modules-core/issues/2991) was fixed in Ansible 2.1 that allows `docker_image` to be use for pulling images without having to specify the `path` parameter.