### PR TITLE
Add OSSEC role

### DIFF
--- a/ossec/defaults/main.yml
+++ b/ossec/defaults/main.yml
@@ -1,0 +1,32 @@
+---
+
+ossec_base_url: "https://github.com/ossec/ossec-hids/archive"
+ossec_version: "2.8.3"
+ossec_archive: "v{{ ossec_version }}.tar.gz"
+ossec_checksum: "sha256:917989e23330d18b0d900e8722392cdbe4f17364a547508742c0fd005a1df7dd"
+ossec_download_dir: "/tmp/ossec"
+ossec_prerequisites:
+  - build-essential
+  - gcc
+  - inotify-tools
+  - libssl-dev
+  - make
+
+ossec_install_type: "agent"
+ossec_language: "en"
+ossec_host_ip: "{{ ansible_default_ipv4.address }}"
+ossec_syscheck_enabled: "y"
+ossec_rootcheck_enabled: "y"
+ossec_active_response_enabled: "n"
+ossec_alert_email_enabled: "n"
+ossec_alert_email_address: ""
+ossec_alert_email_smtp: ""
+ossec_remote_syslog_enabled: "n"
+ossec_firewall_response_enabled: "n"
+ossec_ip_whitelist: "10.0.0.0/8"
+ossec_openssl_config: "openssl.cnf"
+ossec_authd_port: 1515
+ossec_authd_state: "started"
+ossec_authd_enabled: yes
+ossec_server_ip: ""
+ossec_force_restart: no

--- a/ossec/handlers/main.yml
+++ b/ossec/handlers/main.yml
@@ -1,0 +1,11 @@
+---
+
+- name: reload systemd configuration
+  command: systemctl daemon-reload
+
+- name: restart ossec
+  service: name=ossec state=restarted
+
+- name: restart ossec-authd
+  service: name=ossec-authd state=restarted
+  when: ossec_authd_state != "stopped"

--- a/ossec/tasks/main.yml
+++ b/ossec/tasks/main.yml
@@ -1,0 +1,83 @@
+---
+
+- name: Install prerequisites
+  apt: name="{{ item }}" state=present
+  with_items: ossec_prerequisites
+  tags: ['ossec', 'ossec:install']
+
+- name: Create download directory
+  file: path="{{ ossec_download_dir }}" state=directory mode=0755
+  tags: ['ossec', 'ossec:install']
+
+- name: Download OSSEC
+  get_url: >
+    url="{{ ossec_base_url }}/{{ ossec_archive }}"
+    dest="{{ ossec_download_dir }}/{{ ossec_archive }}"
+    checksum="{{ ossec_checksum }}"
+  tags: ['ossec', 'ossec:install']
+
+- name: Unarchive OSSEC
+  unarchive: >
+    src="{{ ossec_download_dir  }}/{{ ossec_archive }}"
+    dest="{{ ossec_download_dir }}"
+    copy=no
+  tags: ['ossec', 'ossec:install']
+
+- name: Set build configuration options
+  template: >
+    src="preloaded-vars.conf"
+    dest="{{ ossec_download_dir }}/ossec-hids-{{ ossec_version }}/etc/preloaded-vars.conf"
+  tags: ['ossec', 'ossec:install']
+
+- name: Install OSSEC
+  command: >
+    "{{ ossec_download_dir }}/ossec-hids-{{ ossec_version }}/install.sh"
+    chdir="{{ ossec_download_dir }}/ossec-hids-{{ ossec_version }}"
+    creates="/var/ossec/bin/ossec-control"
+  tags: ['ossec', 'ossec:install']
+
+- name: Copy OpenSSL configuration
+  template: src="{{ ossec_openssl_config }}" dest="{{ ossec_download_dir }}/{{ ossec_openssl_config | basename }}"
+  when: ossec_install_type == "server"
+  tags: ['ossec', 'ossec:configuration']
+
+- name: Generate TLS certificate
+  command: >
+    openssl req -x509 -days 3650 -newkey rsa:4096 -nodes -sha256
+    -keyout /var/ossec/etc/sslmanager.key -out /var/ossec/etc/sslmanager.cert
+    -config {{ ossec_download_dir }}/{{ ossec_openssl_config | basename }}
+    creates=/var/ossec/etc/sslmanager.cert
+  when: ossec_install_type == "server"
+  tags: ['ossec', 'ossec:configuration']
+
+- name: Copy systemd service file for ossec-authd
+  template: src=ossec-authd.service dest=/etc/systemd/system/ossec-authd.service mode=0644
+  notify:
+    - reload systemd configuration
+    - restart ossec-authd
+  when: ossec_install_type == "server"
+  tags: ['ossec', 'ossec:configuration']
+
+- name: Set state of ossec-authd service
+  service: name=ossec-authd state="{{ ossec_authd_state }}" enabled="{{ ossec_authd_enabled }}"
+  when: ossec_install_type == "server"
+  tags: ['ossec', 'ossec:configuration']
+
+- name: Obtain agent key
+  command: >
+    /var/ossec/bin/agent-auth -m {{ ossec_server_ip }} -p {{ ossec_authd_port }}
+    creates="/var/ossec/etc/client.keys"
+  notify: restart ossec
+  when: ossec_install_type == "agent"
+  tags: ['ossec', 'ossec:configuration']
+
+- name: Start OSSEC
+  service: name=ossec state=started
+  tags: ['ossec', 'ossec:configuration']
+
+- name: Trigger handler to restart OSSEC
+  command: "/bin/true"
+  notify: restart ossec
+  when: ossec_force_restart
+  tags: ['ossec', 'ossec:configuration']
+

--- a/ossec/templates/openssl.cnf
+++ b/ossec/templates/openssl.cnf
@@ -1,0 +1,13 @@
+[ req ]
+default_bits           = 4096
+distinguished_name     = req_distinguished_name
+prompt                 = no
+
+[ req_distinguished_name ]
+C                      =
+ST                     =
+L                      =
+O                      =
+OU                     =
+CN                     =
+emailAddress           =

--- a/ossec/templates/ossec-authd.service
+++ b/ossec/templates/ossec-authd.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=OSSEC authentication service
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+ExecStart=/var/ossec/bin/ossec-authd -p {{ ossec_authd_port }}
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target

--- a/ossec/templates/preloaded-vars.conf
+++ b/ossec/templates/preloaded-vars.conf
@@ -1,0 +1,21 @@
+USER_LANGUAGE="en"
+USER_NO_STOP="y"
+USER_INSTALL_TYPE="{{ ossec_install_type }}"
+USER_DIR="/var/ossec"
+USER_DELETE_DIR="y"
+USER_ENABLE_SYSCHECK="{{ ossec_syscheck_enabled }}"
+USER_ENABLE_ROOTCHECK="{{ ossec_rootcheck_enabled }}"
+USER_ENABLE_ACTIVE_RESPONSE="{{ ossec_active_response_enabled }}"
+USER_UPDATE="y"
+USER_UPDATE_RULES="y"
+
+### Agent Installation variables. ###
+USER_AGENT_SERVER_IP="{{ ossec_host_ip }}"
+
+### Server/Local Installation variables. ###
+USER_ENABLE_EMAIL="{{ ossec_alert_email_enabled }}"
+USER_EMAIL_ADDRESS="{{ ossec_alert_email_address }}"
+USER_EMAIL_SMTP="{{ ossec_alert_email_smtp }}"
+USER_ENABLE_SYSLOG="{{ ossec_remote_syslog_enabled }}"
+USER_ENABLE_FIREWALL_RESPONSE="{{ ossec_firewall_response_enabled }}"
+USER_WHITE_LIST="{{ ossec_ip_whitelist }}"


### PR DESCRIPTION
This PR installs and configures OSSEC either as an agent or a server.

The server runs the `ossec-authd` service, which listens on port 1515 by default and allows agents to register. To configure a machine as a server, you must set `ossec_install_type: "server"`.

When OSSEC runs as an agent, it must register with `ossec_authd` on the server by running the `agent-auth` command. When configuring OSSEC as an agent, you must set `ossec_server_ip` with the IP address of the machine running in server mode.