### PR TITLE
Allow specifying custom rules for Snort

### DIFF
--- a/snort/defaults/main.yml
+++ b/snort/defaults/main.yml
@@ -28,6 +28,9 @@ snort_config_path: "{{ snort_config_dir }}/snort.conf"
 
 snort_home_network: "10.0.0.0/8"
 snort_oinkcode: "oinkoink"
+snort_custom_rules_files:
+  - "custom.rules"
+snort_custom_rules: []
 snort_force_restart: no
 
 snort_pulledpork_base_url: "https://github.com/shirkdog/pulledpork/archive"
@@ -42,3 +45,4 @@ snort_pulledpork_rule_urls:
   - "https://snort.org/downloads/community/|community-rules.tar.gz|Community"
   - "http://talosintelligence.com/feeds/ip-filter.blf|IPBLACKLIST|open"
   - "https://www.snort.org/reg-rules/|opensource.gz|{{ snort_oinkcode }}"
+snort_pulledpork_ips_policy : "balanced"  # security, connectivity, or balanced

--- a/snort/tasks/main.yml
+++ b/snort/tasks/main.yml
@@ -69,6 +69,12 @@
   notify: restart snort
   tags: ['snort', 'snort:configuration']
 
+- name: Copy custom rules
+  template: src="{{ item }}" dest="{{ snort_config_dir }}/rules/{{ item | basename }}"
+  notify: restart snort
+  with_items: snort_custom_rules_files
+  tags: ['snort', 'snort:configuration']
+
 - name: Copy systemd service file
   template: src=snort.service dest=/etc/systemd/system/snort.service mode=0644
   notify:

--- a/snort/templates/custom.rules
+++ b/snort/templates/custom.rules
@@ -1,0 +1,3 @@
+{% for rule in snort_custom_rules %}
+{{ rule }}
+{% endfor %}

--- a/snort/templates/pulledpork.conf
+++ b/snort/templates/pulledpork.conf
@@ -210,6 +210,7 @@ pid_path=/var/run/snort_{{ ansible_default_ipv4.interface }}.pid
 # Note that setting this value will disable all ET rulesets if you are 
 # Running such rulesets
 # ips_policy=security
+ips_policy={{ snort_pulledpork_ips_policy }}
 
 ####### Remember, a number of these values are optional.. if you don't 
 ####### need to process so_rules, simply comment out the so_rule section

--- a/snort/templates/snort.conf
+++ b/snort/templates/snort.conf
@@ -540,6 +540,9 @@ include reference.config
 # site specific rules
 include $RULE_PATH/local.rules
 include $RULE_PATH/snort.rules
+{% for rule_file in snort_custom_rules_files %}
+include $RULE_PATH/{{ rule_file | basename }}
+{% endfor %}
 #
 #include $RULE_PATH/app-detect.rules
 #include $RULE_PATH/attack-responses.rules


### PR DESCRIPTION
A list of custom snort rules can be specified by setting the `snort_custom_rules` variable. By default, these are inserted into the `custom.rules` template and stored on the remote machine at `/etc/snort/rules/custom.rules`. Custom rules files/templates can be specified by setting `snort_custom_rules_files`.

This PR also allows for setting the Pulled Pork IPS Policy via the `snort_pulledpork_ips_policy` variable. This basically controls which rules are enabled so that different levels of strictness can be used. See the [Pulled Pork docs](https://github.com/shirkdog/pulledpork/blob/master/doc/README.RULESET) for details.

Depends on https://github.com/appsembler/roles/pull/7