### PR TITLE
Forward Snort alerts to PagerDuty

### DIFF
--- a/snort/defaults/main.yml
+++ b/snort/defaults/main.yml
@@ -46,3 +46,7 @@ snort_pulledpork_rule_urls:
   - "http://talosintelligence.com/feeds/ip-filter.blf|IPBLACKLIST|open"
   - "https://www.snort.org/reg-rules/|opensource.gz|{{ snort_oinkcode }}"
 snort_pulledpork_ips_policy : "balanced"  # security, connectivity, or balanced
+
+snort_snort2pd_enabled: no
+snort_snort2pd_config_dir: "/etc/snort2pd"
+snort_snort2pd_config: {}

--- a/snort/files/snort2pd.py
+++ b/snort/files/snort2pd.py
@@ -5,6 +5,7 @@ import datetime
 import hashlib
 import json
 import logging
+from platform import node
 import re
 from subprocess import Popen, PIPE
 import sys
@@ -96,7 +97,7 @@ def wait_for_alerts(pager, config):
         if (check_timestamp(log['timestamp'], START_TIME) and
                 incident_key not in incident_keys and
                 int(log['priority']) <= alert_priority):
-            description = 'Snort: {}'.format(log['message'])
+            description = 'Snort: {} [{}]'.format(log['message'], node())
             incident = pager.create_event(service_key, description, 'trigger',
                                           log, incident_key)
             incident_keys.add(incident_key)

--- a/snort/files/snort2pd.py
+++ b/snort/files/snort2pd.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python
+
+from copy import deepcopy
+import datetime
+import hashlib
+import json
+import logging
+import re
+from subprocess import Popen, PIPE
+import sys
+
+from pygerduty import PagerDuty
+
+
+START_TIME = datetime.datetime.utcnow()
+
+# Log example:
+# 01/09-20:42:02.184887  [**] [1:20000:0] ICMP Packet found [**] [Priority: 0] {ICMP} 10.128.0.3 -> 10.128.0.2
+LOG_FORMAT = r"""
+             (?P<timestamp>\d+/\d+-\d+:\d+:\d+\.\d+)\s+
+             \[\*\*\]\s+
+             \[(?P<gid>\d+):(?P<sid>\d+):(?P<rev>\d+)\]\s+
+             (?P<message>[\w\s!@#$%\^&\*()+=;\'",.?~`/]+)\s+
+             \[\*\*\]\s+
+             \[Priority:\s+(?P<priority>\d+)\]\s+
+             \{(?P<protocol>\w+)\}\s+
+             (?P<src>\d+\.\d+\.\d+\.\d+(:\d+)?)\s+
+             ->\s+
+             (?P<dest>\d+\.\d+\.\d+\.\d+(:\d+)?)
+             """
+
+DEFAULT_CONFIG = {
+    'snort_log_path': '/var/log/snort/alert',
+    'snort_log_format': LOG_FORMAT,
+    'snort_alert_priority': 2,
+    'pagerduty_subdomain': 'example',
+    'pagerduty_api_token': '',
+    'pagerduty_service_key': '',
+}
+
+
+def read_logs(log_path):
+    """Tail a log file and yield lines from it"""
+
+    p = Popen(['tail', '-F', log_path], stdout=PIPE)
+    while True:
+        yield p.stdout.readline()
+
+
+def parse_log(log, log_format):
+    """Parse a log line into a dict using a regex"""
+
+    pattern = re.compile(log_format, re.VERBOSE)
+    match = pattern.match(log)
+
+    if not match:
+        msg = 'Log entry did match our pattern: {}'.format(log)
+        logging.warning(msg)
+        return None
+
+    fields = {}
+    for field in pattern.groupindex.keys():
+        fields[field] = match.group(field)
+
+    return fields
+
+
+def check_timestamp(snort_timestamp, date):
+    """Check whether the Snort timestamp is later than the given date"""
+
+    return snort_timestamp > date.strftime('%m/%d-%H:%M:%S.%f')
+
+
+def get_incident_key(log, fields):
+    """Compute a key based on a hash of the log entry."""
+
+    # Prevent duplicate alerts in the same day
+    data = ''.join(log[field] for field in fields)
+    data += datetime.datetime.utcnow().strftime('%Y-%j')
+    return hashlib.sha256(data).hexdigest()
+
+
+def wait_for_alerts(pager, config):
+    """Monitor a log file and send PagerDuty alerts"""
+
+    log_path = config['snort_log_path']
+    log_format = config['snort_log_format']
+    alert_priority = config['snort_alert_priority']
+    service_key = config['pagerduty_service_key']
+
+    incident_keys = set()
+    for log_entry in read_logs(log_path):
+        log = parse_log(log_entry, log_format)
+        incident_key = get_incident_key(log, ('message', 'src', 'dest'))
+
+        if (check_timestamp(log['timestamp'], START_TIME) and
+                incident_key not in incident_keys and
+                int(log['priority']) <= alert_priority):
+            description = 'Snort: {}'.format(log['message'])
+            incident = pager.create_event(service_key, description, 'trigger',
+                                          log, incident_key)
+            incident_keys.add(incident_key)
+
+            yield log, incident
+
+
+def load_config():
+    """Load configuration from a JSON file"""
+
+    config = deepcopy(DEFAULT_CONFIG)
+    with open('/etc/snort2pd/snort2pd.json', 'r') as f:
+        config.update(json.load(f))
+
+    return config
+
+
+def main():
+    config = load_config()
+    pager = PagerDuty(config['pagerduty_subdomain'],
+                      config['pagerduty_api_token'])
+
+    for log, incident in wait_for_alerts(pager, config):
+        msg = {'log': log, 'incident_key': incident}
+        logging.info(str(msg))
+
+if __name__ == '__main__':
+    logging.basicConfig(stream=sys.stdout, level=logging.INFO)
+    main()

--- a/snort/handlers/main.yml
+++ b/snort/handlers/main.yml
@@ -5,3 +5,7 @@
 
 - name: restart snort
   service: name=snort state=restarted
+
+- name: restart snort2pd
+  service: name=snort2pd state=restarted
+  when: snort_snort2pd_enabled

--- a/snort/tasks/main.yml
+++ b/snort/tasks/main.yml
@@ -97,3 +97,5 @@
   tags: ['snort', 'snort:configuration']
 
 - include: pulledpork.yml
+
+- include: snort2pd.yml

--- a/snort/tasks/snort2pd.yml
+++ b/snort/tasks/snort2pd.yml
@@ -1,0 +1,38 @@
+---
+
+- name: Install pygerduty
+  pip: name=pygerduty version=0.35.2
+  tags: ['snort', 'snort:snort2pd']
+
+- name: Install snort2pd
+  copy: src=snort2pd.py dest=/usr/local/bin/snort2pd mode=0755
+  notify: restart snort2pd
+  tags: ['snort', 'snort:snort2pd']
+
+- name: Create snort2pd configuration directory
+  file: path="{{ snort_snort2pd_config_dir }}" state=directory
+  tags: ['snort', 'snort:snort2pd']
+
+- name: Copy snort2pd config file
+  template: src="snort2pd.json" dest="{{ snort_snort2pd_config_dir  }}/snort2pd.json"
+  notify: restart snort2pd
+  tags: ['snort', 'snort:snort2pd']
+
+- name: Copy systemd service file for snort2pd
+  template: >
+    src=snort2pd.service
+    dest=/etc/systemd/system/snort2pd.service
+    mode=0644
+  notify:
+    - reload systemd configuration
+    - restart snort2pd
+  tags: ['snort', 'snort:snort2pd']
+
+- name: Enable snort2pd service
+  service: name=snort2pd enabled="{{ snort_snort2pd_enabled }}"
+  tags: ['snort', 'snort:snort2pd']
+
+- name: Start snort2pd
+  service: name=snort2pd state=started
+  when: snort_snort2pd_enabled
+  tags: ['snort', 'snort:snort2pd']

--- a/snort/templates/snort2pd.json
+++ b/snort/templates/snort2pd.json
@@ -1,0 +1,1 @@
+{{ snort_snort2pd_config | to_nice_json }}

--- a/snort/templates/snort2pd.service
+++ b/snort/templates/snort2pd.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=snort2pd -- Forward Snort alerts to PagerDuty
+Wants=snort.service
+After=snort.service
+
+[Service]
+ExecStart=/usr/local/bin/snort2pd
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
This PR adds the `snort2pd` service, which tails the Snort log file and sends alerts to PagerDuty. `snort2pd` needs a PagerDuty API token, service key, and subdomain, which can  be set with `snort_snort2pd_config`, e.g.

```
snort_snort2pd_config:
  pagerduty_subdomain: "appsembler"
  pagerduty_api_token: "{{ secret_snort_snort2pd_config_pagerduty_api_token }}"
  pagerduty_service_key: "{{ secret_snort_snort2pd_config_pagerduty_service_key }}"
```