### PR TITLE
Add logstash configs for snort and pagerduty

### DIFF
--- a/logstash/defaults/main.yml
+++ b/logstash/defaults/main.yml
@@ -16,10 +16,12 @@ logstash_default_configs:
   - "20_openedx_filter.conf"
   - "20_postgresql_filter.conf"
   - "20_redis_filter.conf"
+  - "20_snort_filter.conf"
   - "20_syslog_filter.conf"
   - "20_uwsgi_filter.conf"
   - "24_grokparsefailure_filter.conf"
   - "30_elasticsearch_output.conf"
+  - "30_pagerduty_output.conf"
 logstash_custom_configs: []
 
 logstash_remove_patterns: no
@@ -33,6 +35,7 @@ logstash_default_patterns:
   - "openedx"
   - "postgresql"
   - "redis"
+  - "snort"
   - "uwsgi"
 logstash_custom_patterns: []
 

--- a/logstash/files/snort
+++ b/logstash/files/snort
@@ -1,0 +1,2 @@
+SNORT_TIMESTAMP %{INT:month}/%{INT:day}-%{INT:hour}:%{INT:minute}:%{INT:second}\.%{INT:microseconds}
+SNORT %{SNORT_TIMESTAMP}%{SPACE}\[\*\*\] \[%{INT:gid}:%{INT:sid}:%{INT:rev}] %{DATA:message} \[\*\*\] \[Priority: %{INT:priority}\] \{%{WORD:protocol}\} %{IPV4:src}(:%{INT:src_port})? -> %{IPV4:dest}(:%{INT:dest_port})?

--- a/logstash/templates/20_snort_filter.conf
+++ b/logstash/templates/20_snort_filter.conf
@@ -1,0 +1,11 @@
+filter {
+  if [type] == "snort" {
+    grok {
+      match => { "message" => "%{SNORT}" }
+      overwrite => [ "message" ]
+{% if logstash_filter_tags|length %}
+      add_tag => ["{{ logstash_filter_tags | join('\", \"') }}"]
+{% endif %}
+    }
+  }
+}

--- a/logstash/templates/20_ssh_filter.conf
+++ b/logstash/templates/20_ssh_filter.conf
@@ -1,0 +1,11 @@
+filter {
+  if [type] == "syslog" {
+    grok {
+      match => { "message" => ["%{SSH_CONNECTION}", "%{SSH_ACCEPTED}"] }
+      overwrite => [ "message" ]
+{% if logstash_filter_tags|length %}
+      add_tag => ["{{ logstash_filter_tags | join('\", \"') }}"]
+{% endif %}
+    }
+  }
+}

--- a/logstash/templates/30_pagerduty_output.conf
+++ b/logstash/templates/30_pagerduty_output.conf
@@ -5,6 +5,8 @@ output {
       service_key => "{{ logstash_output_pagerduty_service_key }}"
       description => "{{ item.description }}"
       incident_key => "{{ item.incident_key | default('logstash/%{host}/%{type}')}}"
+      details => { {% for k, v in item.details.items() %}"{{ k }}" => "{{ v }}"
+                   {% endfor %} }
     }
   }
 {% endfor %}

--- a/logstash/templates/30_pagerduty_output.conf
+++ b/logstash/templates/30_pagerduty_output.conf
@@ -1,0 +1,11 @@
+output {
+{% for item in logstash_output_pagerduty_alerts %}
+  if [type] == "{{ item.type }}" {
+    pagerduty {
+      service_key => "{{ logstash_output_pagerduty_service_key }}"
+      description => "{{ item.description }}"
+      incident_key => "{{ item.incident_key | default('logstash/%{host}/%{type}')}}"
+    }
+  }
+{% endfor %}
+}


### PR DESCRIPTION
This PR makes it possible to parse Snort alert logs and create PagerDuty alerts.

Example configuration to send Snort alerts to PagerDuty:

```
logstash_output_pagerduty_service_key: "{{ secret_logstash_output_pagerduty_service_key }}"
logstash_output_pagerduty_alerts:
  - type: "snort"
    description: "Snort: %{message} [%{host}]"
    incident_key: "snort%{month}%{day}%{message}%{src}%{dest}"
    details:
      host: "%{host}"
      messsage: "%{message}"
      protocol: "%{protocol}"
      source: "%{src}"
      desination: "%{dest}"
```

Alternative to https://github.com/appsembler/roles/pull/11