### PR TITLE
Add letsencrypt and gcsfuse roles

### DIFF
--- a/gcsfuse/defaults/main.yml
+++ b/gcsfuse/defaults/main.yml
@@ -1,0 +1,24 @@
+---
+
+gcsfuse_repo: "deb http://packages.cloud.google.com/apt gcsfuse-{{ ansible_distribution_release }} main"
+gcsfuse_apt_key_url: "https://packages.cloud.google.com/apt/doc/apt-key.gpg"
+gcsfuse_package: "gcsfuse"
+gcsfuse_mounts: []
+gcsfuse_keyfiles: []
+
+#gcsfuse_mounts:
+#  - bucket: "my-bucket"
+#    path: "/var/lib/mounts/my-bucket"
+#    owner: "my-user"
+#    group: "my-group"
+#    mode: "0770"
+#    keyfile: "/etc/credentials/service-account-creds.json"
+#
+#gcsfuse_keyfiles:
+#  - content: |
+#      Ym/20U0uqaLgtsMKHAG6TbGoM6Y9B27ruX0rSXb6F4dRIgoTbJ20Lg+e/UxQSPBWaTsh6QXl9noI
+#      ew3BumVLglS14ws4okuMHtPCycx33G/uEdSM5U/wRjOaBNiWV6SM/O2NQg==
+#    dest: "/etc/credentials/service-account-creds.json"
+#    owner: "my-user"
+#    group: "my-group"
+#    mode: "0440"

--- a/gcsfuse/tasks/main.yml
+++ b/gcsfuse/tasks/main.yml
@@ -48,4 +48,14 @@
   become: True
   become_user: "{{ item.owner | default('root') }}"
   with_items: "{{ gcsfuse_mounts }}"
-  tags: ['gcsfuse', 'gcsfuse:configuration', 'morgan']
+  tags: ['gcsfuse', 'gcsfuse:configuration']
+
+- name: Mount buckets on reboot
+  cron:
+    name: "Mount bucket `{{ item.bucket }}` at `{{ item.path }}`"
+    cron_file: "gcsfuse"
+    special_time: "reboot"
+    job: gcsfuse {{ (item.keyfile != None) | ternary("--key-file " + item.keyfile, "") }} "{{ item.bucket }}" "{{ item.path }}" && touch "{{ item.path }}/.mounted"
+    user: "{{ item.owner | default('root') }}"
+  with_items: "{{ gcsfuse_mounts }}"
+  tags: ['gcsfuse', 'gcsfuse:configuration']

--- a/gcsfuse/tasks/main.yml
+++ b/gcsfuse/tasks/main.yml
@@ -1,0 +1,51 @@
+---
+
+- name: Add gcsfuse repo
+  apt_repository: repo="{{ gcsfuse_repo }}"
+  tags: ['gcsfuse', 'gcsfuse:install']
+
+- name: Add repository key
+  apt_key: url="{{ gcsfuse_apt_key_url }}"
+  tags: ['gcsfuse', 'gcsfuse:install']
+
+- name: Install gcsfuse
+  apt: name="{{ gcsfuse_package }}" update_cache=yes
+  tags: ['gcsfuse', 'gcsfuse:install']
+
+- name: Create mount directories
+  file:
+    state: directory
+    path: "{{ item.path }}"
+    owner: "{{ item.owner | default(omit) }}"
+    group: "{{ item.group | default(omit) }}"
+    mode: "{{ item.mode | default(omit) }}"
+  become: True
+  become_user: "{{ item.owner | default('root') }}"
+  with_items: "{{ gcsfuse_mounts }}"
+  tags: ['gcsfuse', 'gcsfuse:configuration']
+
+- name: Create directories for credentials files
+  file:
+    state: directory
+    path: "{{ item.dest | dirname }}"
+  with_items: "{{ gcsfuse_keyfiles }}"
+  tags: ['gcsfuse', 'gcsfuse:configuration']
+
+- name: Copy credentials files for service accounts
+  copy:
+    content: "{{ item.content | b64decode }}"
+    dest: "{{ item.dest }}"
+    owner: "{{ item.owner | default(omit) }}"
+    group: "{{ item.group | default(omit) }}"
+    mode: "{{ item.mode | default(omit) }}"
+  with_items: "{{ gcsfuse_keyfiles }}"
+  tags: ['gcsfuse', 'gcsfuse:configuration']
+
+- name: Mount buckets in directories
+  shell: gcsfuse {{ (item.keyfile != None) | ternary("--key-file " + item.keyfile, "") }} "{{ item.bucket }}" "{{ item.path }}" && touch "{{ item.path }}/.mounted"
+  args:
+    creates: "{{ item.path }}/.mounted"
+  become: True
+  become_user: "{{ item.owner | default('root') }}"
+  with_items: "{{ gcsfuse_mounts }}"
+  tags: ['gcsfuse', 'gcsfuse:configuration', 'morgan']

--- a/letsencrypt/defaults/main.yml
+++ b/letsencrypt/defaults/main.yml
@@ -1,0 +1,17 @@
+---
+
+letsencrypt_webroot: "/var/www/letsencrypt"
+letsencrypt_webuser: "www-data"
+letsencrypt_webserver: "nginx"
+letsencrypt_webserver_config: "nginx/letsencrypt"
+letsencrypt_webserver_sites_available: "/etc/nginx/sites-available"
+letsencrypt_webserver_sites_enabled: "/etc/nginx/sites-enabled"
+letsencrypt_https_redirect: false
+letsencrypt_email: !!null
+letsencrypt_certs: []
+letsencrypt_flags: ""
+
+# This must be a list of hashes, where each hash represents a single certificate
+# letsencrypt_certs:
+#   - domains: ["foo.example.com", "bar.example.com"]
+#   - domains: ["baz.example.com"]

--- a/letsencrypt/defaults/main.yml
+++ b/letsencrypt/defaults/main.yml
@@ -1,5 +1,7 @@
 ---
 
+letsencrypt_package: "letsencrypt"
+letsencrypt_command: "letsencrypt"
 letsencrypt_webroot: "/var/www/letsencrypt"
 letsencrypt_webuser: "www-data"
 letsencrypt_webserver: "nginx"

--- a/letsencrypt/tasks/main.yml
+++ b/letsencrypt/tasks/main.yml
@@ -1,0 +1,67 @@
+---
+
+- name: Install Let's Encrypt
+  apt: name="letsencrypt"
+  tags: ['letsencrypt']
+
+- name: Create Let's Encrypt directories
+  file:
+    state: directory
+    path: "{{ item }}"
+    owner: "{{ letsencrypt_webuser }}"
+    group: "{{ letsencrypt_webuser }}"
+  with_items: 
+    - "/etc/letsencrypt"
+    - "/var/log/letsencrypt"
+    - "/var/lib/letsencrypt"
+  tags: ['letsencrypt']
+
+- name: Create Let's Encrypt webroot directory
+  file: 
+    state: directory
+    path: "{{ letsencrypt_webroot }}"
+    owner: "{{ letsencrypt_webuser }}"
+    group: "{{ letsencrypt_webuser }}"
+  become: True
+  become_user: "{{ letsencrypt_webuser }}"
+  tags: ['letsencrypt']
+
+- name: Copy nginx config
+  template:
+    src: "{{ letsencrypt_webserver_config }}"
+    dest: "{{ letsencrypt_webserver_sites_available }}/{{ letsencrypt_webserver_config | basename }}"
+  when: letsencrypt_webserver == "nginx"
+  tags: ['letsencrypt']
+
+- name: Enable nginx config
+  file:
+    state: link
+    path: "{{ letsencrypt_webserver_sites_enabled }}/{{ letsencrypt_webserver_config | basename }}"
+    src: "{{ letsencrypt_webserver_sites_available }}/{{ letsencrypt_webserver_config | basename }}"
+  when: letsencrypt_webserver == "nginx"
+  tags: ['letsencrypt']
+
+- name: Reload nginx
+  service: name=nginx state=reloaded
+  when: letsencrypt_webserver == "nginx"
+  tags: ['letsencrypt']
+
+- name: Generate certificates using webroot
+  command: >
+    letsencrypt certonly {{ letsencrypt_flags }} --agree-tos -m "{{ letsencrypt_email }}"
+    --webroot -w "{{ letsencrypt_webroot }}" -d {{ item.domains | join(' -d ') }}
+  args:
+    creates: /etc/letsencrypt/live/{{ item.domains[0] }}/fullchain.pem
+  with_items: "{{ letsencrypt_certs }}"
+  become: True
+  become_user: "{{ letsencrypt_webuser }}"
+  tags: ['letsencrypt']
+
+- name: Create cron job to renew certificates
+  cron: >
+    name="Let's Encrypt certificate renewal"
+    cron_file="letsencrypt"
+    special_time="daily"
+    user="root"
+    job="letsencrypt renew --agree-tos"
+  tags: ['letsencrypt']

--- a/letsencrypt/tasks/main.yml
+++ b/letsencrypt/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: Install Let's Encrypt
-  apt: name="letsencrypt"
+  apt: name="{{ letsencrypt_package }}"
   tags: ['letsencrypt']
 
 - name: Create Let's Encrypt directories
@@ -48,7 +48,7 @@
 
 - name: Generate certificates using webroot
   command: >
-    letsencrypt certonly {{ letsencrypt_flags }} --agree-tos -m "{{ letsencrypt_email }}"
+    {{ letsencrypt_command }} certonly {{ letsencrypt_flags }} --agree-tos -m "{{ letsencrypt_email }}"
     --webroot -w "{{ letsencrypt_webroot }}" -d {{ item.domains | join(' -d ') }}
   args:
     creates: /etc/letsencrypt/live/{{ item.domains[0] }}/fullchain.pem
@@ -63,5 +63,5 @@
     cron_file="letsencrypt"
     special_time="daily"
     user="root"
-    job="letsencrypt renew --agree-tos"
+    job="{{ letsencrypt_command }} renew --agree-tos"
   tags: ['letsencrypt']

--- a/letsencrypt/templates/nginx/letsencrypt
+++ b/letsencrypt/templates/nginx/letsencrypt
@@ -1,0 +1,21 @@
+{% set domains = [] %}
+{% for item in letsencrypt_certs %}
+{% set domains = domains.extend(item.domains) %}
+{% endfor %}
+server {
+    listen 80;
+    listen [::]:80;
+    server_name {{ domains | unique | join(' ') }};
+
+    location '/.well-known/acme-challenge' {
+        default_type "text/plain";
+        root {{ letsencrypt_webroot }};
+    }
+
+{% if letsencrypt_https_redirect %}
+    location / {
+        # Redirect to https
+        return 301 https://$host$request_uri;
+    }
+{% endif %}
+}


### PR DESCRIPTION
This PR provides the ability to generate TLS certificates for nginx using the [webroot plugin](https://letsencrypt.readthedocs.io/en/latest/using.html#webroot) for Let's Encrypt. The webroot plugin uses the [http-01](https://github.com/ietf-wg-acme/acme/blob/master/draft-ietf-acme-acme.md#user-content-http) challenge and stores challenge response data in the directory specified by `letsencrypt_webroot`.

When generating certificates behind a load balancer, it's necessary for all servers in the pool to have access to the challenge response data. On GCP, [gcsfuse](https://github.com/GoogleCloudPlatform/gcsfuse) can be used to mount a shared Google Storage bucket to the `letsencrypt_webroot` directory.

Example configuration:

```
# Directory where the challenge response data will be stored
letsencrypt_webroot: "/var/www/letsencrypt"

# User that needs access to `letsencrypt_webroot` (i.e. the user that runs nginx)
letsencrypt_webuser: "www-data"

# This will generate two separate certs, one for foo.example.com and
# bar.example.com, and the other for baz.example.com
letsencrypt_certs:
 - domains: ["foo.example.com", "bar.example.com"]
 - domains: ["baz.example.com"]

# Set this if your sites-available directory is in a weird place
letsencrypt_webserver_sites_available: "/edx/app/nginx/sites-available"

# Email address associated with generated certificates
letsencrypt_email: "info@example.com"

# Extra options to pass to letsencrypt
# You can use `--staging` to generate non-valid certs for testing
letsencrypt_flags: "--staging"

# Google Storage buckets and their mount points
gcsfuse_mounts:
  - bucket: "my-bucket"
    path: "{{ letsencrypt_webroot }}"
    owner: "{{ letsencrypt_webuser }}"
    group: "{{ letsencrypt_webuser }}"
    mode: "0770"
    keyfile: "/etc/credentials/creds.json"

# base64-encoded contents of json credentials file for a service account with
# access to the bucket
secret_gcsfuse_keyfile: |
    Ym/20U0uqaLgtsMKHAG6TbGoM6Y9B27ruX0rSXb6F4dRIgoTbJ20Lg+e/UxQSPBWaTsh6QXl9noI
    ew3BumVLglS14ws4okuMHtPCycx33G/uEdSM5U/wRjOaBNiWV6SM/O2NQg==

gcsfuse_keyfiles:
  - content: "{{ secret_gcsfuse_keyfile }}"
    dest: "/etc/credentials/creds.json"
    owner: "{{ letsencrypt_webuser }}"
    group: "{{ letsencrypt_webuser }}"
    mode: "0440"
```