### PR TITLE
Updates for Ansible 2.2 and Xenial

### DIFF
--- a/consul_template/tasks/main.yml
+++ b/consul_template/tasks/main.yml
@@ -35,7 +35,7 @@
   copy: >
     src="{{ item }}" dest="{{ consul_template_template_dir }}/{{ item | basename }}"
   notify: restart consul-template
-  with_items: consul_template_templates
+  with_items: "{{ consul_template_templates }}"
   tags: ['consul_template', 'consul_template:configuration']
 
 - name: Enable consul-template service

--- a/filebeat/defaults/main.yml
+++ b/filebeat/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 
-filebeat_repo: "deb https://packages.elastic.co/beats/apt stable main"
+filebeat_repo: "deb https://artifacts.elastic.co/packages/5.x/apt stable main"
 filebeat_apt_key_id: "46095ACC8548582C1A2699A9D27D666CD88E42B4"
 filebeat_package: "filebeat"
 filebeat_config_dir: "/etc/filebeat"

--- a/filebeat/tasks/main.yml
+++ b/filebeat/tasks/main.yml
@@ -1,11 +1,11 @@
 ---
 
-- name: Add filebeat repo
-  apt_repository: repo="{{ filebeat_repo }}" state=present
-  tags: ['filebeat', 'filebeat:install']
-
 - name: Add filebeat repository key
   apt_key: keyserver=pgp.mit.edu id="{{ filebeat_apt_key_id }}"
+  tags: ['filebeat', 'filebeat:install']
+
+- name: Add filebeat repo
+  apt_repository: repo="{{ filebeat_repo }}" state=present
   tags: ['filebeat', 'filebeat:install']
 
 - name: Update apt cache

--- a/incron/tasks/main.yml
+++ b/incron/tasks/main.yml
@@ -10,7 +10,7 @@
       create=yes
       line="{{ item.path }} {{ item.mask }} {{ item.command }}"
       state=present
-  with_items: incron_jobs
+  with_items: "{{ incron_jobs }}"
   notify: restart incron
   tags: ['incron', 'incron:configuration']
 

--- a/logstash/defaults/main.yml
+++ b/logstash/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 
-logstash_repo: "deb https://packages.elastic.co/logstash/2.3/debian stable main"
+logstash_repo: "deb https://artifacts.elastic.co/packages/5.x/apt stable main"
 logstash_apt_key_id: "46095ACC8548582C1A2699A9D27D666CD88E42B4"
 logstash_package: "logstash"
 
@@ -47,6 +47,8 @@ logstash_output_elasticsearch_hosts:
   - "localhost:9200"
 logstash_output_elasticsearch_user: ""
 logstash_output_elasticsearch_password: ""
+logstash_output_pagerduty_alerts: []
+logstash_output_pagerduty_service_key: ""
 
 logstash_restart: no
 

--- a/logstash/tasks/main.yml
+++ b/logstash/tasks/main.yml
@@ -1,11 +1,11 @@
 ---
 
-- name: Add logstash repo
-  apt_repository: repo="{{ logstash_repo }}" state=present
-  tags: ['logstash', 'logstash:install']
-
 - name: Add logstash repository key
   apt_key: keyserver=pgp.mit.edu id="{{ logstash_apt_key_id }}"
+  tags: ['logstash', 'logstash:install']
+
+- name: Add logstash repo
+  apt_repository: repo="{{ logstash_repo }}" state=present
   tags: ['logstash', 'logstash:install']
 
 - name: Update apt cache

--- a/logstash/tasks/main.yml
+++ b/logstash/tasks/main.yml
@@ -32,13 +32,13 @@
 
 - name: Copy default logstash configuration files
   template: src="{{ item }}" dest="{{ logstash_config_dir }}/{{ item | basename }}"
-  with_items: logstash_default_configs
+  with_items: "{{ logstash_default_configs }}"
   notify: restart logstash
   tags: ['logstash', 'logstash:configuration']
 
 - name: Copy custom logstash configuration files
   template: src="{{ item }}" dest="{{ logstash_config_dir }}/{{ item | basename }}"
-  with_items: logstash_custom_configs
+  with_items: "{{ logstash_custom_configs }}"
   notify: restart logstash
   tags: ['logstash', 'logstash:configuration']
 
@@ -48,13 +48,13 @@
 
 - name: Copy default logstash patterns
   copy: src="{{ item }}" dest="{{ logstash_pattern_dir }}/{{ item | basename }}"
-  with_items: logstash_default_patterns
+  with_items: "{{ logstash_default_patterns }}"
   notify: restart logstash
   tags: ['logstash', 'logstash:configuration']
 
 - name: Copy custom logstash patterns
   copy: src="{{ item }}" dest="{{ logstash_pattern_dir }}/{{ item | basename }}"
-  with_items: logstash_custom_patterns
+  with_items: "{{ logstash_custom_patterns }}"
   notify: restart logstash
   tags: ['logstash', 'logstash:configuration']
 

--- a/ossec/tasks/main.yml
+++ b/ossec/tasks/main.yml
@@ -2,7 +2,7 @@
 
 - name: Install prerequisites
   apt: name="{{ item }}" state=present
-  with_items: ossec_prerequisites
+  with_items: "{{ ossec_prerequisites }}"
   tags: ['ossec', 'ossec:install']
 
 - name: Create download directory

--- a/sftp/tasks/main.yml
+++ b/sftp/tasks/main.yml
@@ -8,14 +8,14 @@
   file: >
     path="{{ item.chroot }}" state=directory
     owner=root group="{{ sftp_group }}" mode=0755
-  with_items: sftp_users
+  with_items: "{{ sftp_users }}"
   tags: ['sftp']
 
 - name: Create restricted sftp users
   user: >
     name="{{ item.name }}" groups="{{ sftp_group }}"
     home="{{ item.chroot }}" shell="/sbin/nologin"
-  with_items: sftp_users
+  with_items: "{{ sftp_users }}"
   tags: ['sftp']
 
 - name: Create writable directories in the chroot
@@ -31,7 +31,7 @@
   authorized_key: >
     user={{ item.name }}
     key={{ item.pubkey }}
-  with_items: sftp_users
+  with_items: "{{ sftp_users }}"
   tags: ['sftp']
 
 - name: Configure sftp settings

--- a/snort/tasks/main.yml
+++ b/snort/tasks/main.yml
@@ -2,7 +2,7 @@
 
 - name: Install prerequisites
   apt: name="{{ item }}" state=present
-  with_items: snort_prerequisites
+  with_items: "{{ snort_prerequisites }}"
   tags: ['snort', 'snort:install']
 
 - name: Create download directory
@@ -65,14 +65,14 @@
 
 - name: Copy config files
   template: src="{{ item }}" dest="{{ snort_config_dir }}/{{ item | basename }}"
-  with_items: snort_configs
+  with_items: "{{ snort_configs }}"
   notify: restart snort
   tags: ['snort', 'snort:configuration']
 
 - name: Copy custom rules
   template: src="{{ item }}" dest="{{ snort_config_dir }}/rules/{{ item | basename }}"
   notify: restart snort
-  with_items: snort_custom_rules_files
+  with_items: "{{ snort_custom_rules_files }}"
   tags: ['snort', 'snort:configuration']
 
 - name: Copy systemd service file


### PR DESCRIPTION
- Update syntax for `with_items` (quotes and curlies are now required around variable names)
- Update package repos for filebeat and logstash
- Add defaults for `logstash_output_pagerduty_alerts` and `logstash_output_pagerduty_service_key`, which were missing (a bug!)