### PR TITLE
Add ability to monitor URLs with monit

### DIFF
--- a/monit/defaults/main.yml
+++ b/monit/defaults/main.yml
@@ -5,6 +5,7 @@ monit_config_dir: "/etc/monit"
 monit_monitrc: "monitrc"
 monit_extra_config_dir: "{{ monit_config_dir }}/conf.d"
 monit_extra_configs:
+  - "hosts"
   - "system"
 
 monit_log_path: "/var/log/monit.log"
@@ -22,5 +23,24 @@ monit_disk_usage: "90%"
 monit_disk_read_rate: "10 MB/s"
 monit_disk_write_rate: "10 MB/s"
 monit_alert_action: "alert"
+
+monit_check_hosts: []
+# List of hashes. Optionally specify host, port, protocol, status, content, and
+# request in each hash
+# monit_check_hosts:
+#    - host: example.com
+#      port: 443
+#      protocol: https
+#      status: 200
+#      request: /path/to/resource
+
+monit_check_hosts_defaults: {}
+# Defaults so that not every key needs to be specified in each item of
+# monit_check_hosts. Optionally specify host, port, protocol, status, content,
+# and request
+# monit_check_hosts_defaults:
+#   host: example.com
+#   protocol: http
+#   port: 80
 
 monit_force_restart: no

--- a/monit/templates/hosts
+++ b/monit/templates/hosts
@@ -1,0 +1,21 @@
+{% for check_host in monit_check_hosts %}
+check host {{ loop.index }}-{{ check_host.host | default(monit_check_hosts_defaults.host) }} address {{ check_host.host | default(monit_check_hosts_defaults.host) }}
+  if failed
+{% if "port" in check_host or "port" in monit_check_hosts_defaults %}
+    port {{ check_host.port | default(monit_check_hosts_defaults.port) }}
+{% endif %}
+{% if "protocol" in check_host or "protocol" in monit_check_hosts_defaults %}
+    protocol {{ check_host.protocol | default(monit_check_hosts_defaults.protocol) }}
+{% endif %}
+{% if "status" in check_host or "status" in monit_check_hosts_defaults %}
+    status = {{ check_host.status | default(monit_check_hosts_defaults.status) }}
+{% endif %}
+{% if "content" in check_host or "content" in monit_check_hosts_defaults %}
+    content = {{ check_host.content | default(monit_check_hosts_defaults.content) }}
+{% endif %}
+{% if "request" in check_host or "request" in monit_check_hosts_defaults %}
+    request "{{ check_host.request | default(monit_check_hosts_defaults.request) }}"
+{% endif %}
+  for {{ monit_alert_cycles }} cycles
+  then exec "/usr/local/bin/log-monit-alert trigger-hosts 'Check failed for {{ check_host.host | default(monit_check_hosts_defaults.host) }}{{ check_host.request }}'"
+{% endfor %}

--- a/monit/templates/system
+++ b/monit/templates/system
@@ -1,16 +1,16 @@
 check system {{ ansible_hostname }}
 {% if monit_check_cpu_usage %}
-  if cpu usage > {{ monit_cpu_usage }} for {{ monit_alert_cycles }} cycles then exec "/usr/local/bin/log-monit-alert trigger 'CPU usage > {{ monit_cpu_usage }}'"
+  if cpu usage > {{ monit_cpu_usage }} for {{ monit_alert_cycles }} cycles then exec "/usr/local/bin/log-monit-alert trigger-system 'CPU usage > {{ monit_cpu_usage }}'"
 {% endif %}
 {% if monit_check_memory_usage %}
-  if memory usage > {{ monit_memory_usage }} for {{ monit_alert_cycles }} cycles then exec "/usr/local/bin/log-monit-alert trigger 'Memory usage > {{ monit_memory_usage }}'"
+  if memory usage > {{ monit_memory_usage }} for {{ monit_alert_cycles }} cycles then exec "/usr/local/bin/log-monit-alert trigger-system 'Memory usage > {{ monit_memory_usage }}'"
 {% endif %}
 
 check filesystem root with path {{ monit_disk_root }}
 {% if monit_check_disk_usage %}
-  if space usage > {{ monit_disk_usage }} for {{ monit_alert_cycles }} cycles then exec "/usr/local/bin/log-monit-alert trigger 'Disk usage > {{ monit_disk_usage }}'"
+  if space usage > {{ monit_disk_usage }} for {{ monit_alert_cycles }} cycles then exec "/usr/local/bin/log-monit-alert trigger-system 'Disk usage > {{ monit_disk_usage }}'"
 {% endif %}
 {% if monit_check_disk_io %}
-  if read rate > {{ monit_disk_read_rate }} for {{ monit_alert_cycles }} cycles then exec "/usr/local/bin/log-monit-alert trigger 'Disk read rate > {{ monit_disk_read_rate }}'"
-  if write rate > {{ monit_disk_write_rate }} for {{ monit_alert_cycles }} cycles then exec "/usr/local/bin/log-monit-alert trigger 'Disk write rate > {{ monit_disk_write_rate }}'"
+  if read rate > {{ monit_disk_read_rate }} for {{ monit_alert_cycles }} cycles then exec "/usr/local/bin/log-monit-alert trigger-system 'Disk read rate > {{ monit_disk_read_rate }}'"
+  if write rate > {{ monit_disk_write_rate }} for {{ monit_alert_cycles }} cycles then exec "/usr/local/bin/log-monit-alert trigger-system 'Disk write rate > {{ monit_disk_write_rate }}'"
 {% endif %}


### PR DESCRIPTION
This allows us to request URLs to monitor things like static assets.

`monit_check_hosts` is a list of hashes where each hash defines a check. Each hash can optionally specify `host`, `port`, `protocol`, `status`, `request`, and `content`. These are used to configure monit's [`CHECK HOST`](https://mmonit.com/monit/documentation/monit.html#Remote-host) checks. `monit_check_hosts_defaults` can be defined to set default values for each hash in `monit_check_hosts`.