### PR TITLE
Fix Snort/DAQ 404 errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 site/
+/.idea/

--- a/snort/defaults/main.yml
+++ b/snort/defaults/main.yml
@@ -1,12 +1,15 @@
 ---
 
-snort_base_url: "https://snort.org/downloads/snort"
+snort_base_url: "https://downloads.sourceforge.net/project/slackbuildsdirectlinks/snort/"
 snort_version: "2.9.9.0"
-snort_daq_version: "2.0.6"
 snort_archive: "snort-{{ snort_version }}.tar.gz"
-snort_daq_archive: "daq-{{ snort_daq_version}}.tar.gz"
 snort_checksum: "sha256:71b147125e96390a12f3d55796ed5073df77206bd3563d84d3e5a1f19e7d7a56"
+
+snort_daq_base_url: "https://fossies.org/linux/misc/"
+snort_daq_version: "2.0.6"
+snort_daq_archive: "daq-{{ snort_daq_version}}.tar.gz"
 snort_daq_checksum: "sha256:b40e1d1273e08aaeaa86e69d4f28d535b7e53bdb3898adf539266b63137be7cb"
+
 snort_download_dir: "/tmp/snort"
 snort_prerequisites:
   - bison

--- a/snort/tasks/main.yml
+++ b/snort/tasks/main.yml
@@ -11,7 +11,7 @@
 
 - name: Download Snort DAQ
   get_url: >
-    url="{{ snort_base_url }}/{{ snort_daq_archive }}"
+    url="{{ snort_daq_base_url }}/{{ snort_daq_archive }}"
     dest="{{ snort_download_dir }}/{{ snort_daq_archive }}"
     checksum="{{ snort_daq_checksum }}"
   tags: ['snort', 'snort:install']


### PR DESCRIPTION
Neither one of the packages are being downloaded. Which breaks the build!

Probably we should just update snort, but I'd rather rely on @mrgnr to do it since I'm completely unaware of that thing.