### PR TITLE
Add default_option for letsencrypt nginx template

### DIFF
--- a/letsencrypt/defaults/main.yml
+++ b/letsencrypt/defaults/main.yml
@@ -13,10 +13,7 @@ letsencrypt_email: !!null
 letsencrypt_certs: []
 letsencrypt_flags: ""
 letsencrypt_run: true
-
-# needs to be the same name as the variable in the nginx role and defined here as well
-# so that those two roles can be run independently
-nginx_enable_custom_domains: false
+letsencrypt_enable_default_server: false
 
 # This must be a list of hashes, where each hash represents a single certificate
 # letsencrypt_certs:

--- a/letsencrypt/defaults/main.yml
+++ b/letsencrypt/defaults/main.yml
@@ -14,6 +14,10 @@ letsencrypt_certs: []
 letsencrypt_flags: ""
 letsencrypt_run: true
 
+# needs to be the same name as the variable in the nginx role and defined here as well
+# so that those two roles can be run independently
+nginx_enable_custom_domains: false
+
 # This must be a list of hashes, where each hash represents a single certificate
 # letsencrypt_certs:
 #   - domains: ["foo.example.com", "bar.example.com"]

--- a/letsencrypt/templates/nginx/letsencrypt
+++ b/letsencrypt/templates/nginx/letsencrypt
@@ -1,6 +1,12 @@
+{%- if "letsencrypt" in nginx_default_sites -%}
+  {%- set default_site = "default_server" -%}
+{%- else -%}
+  {%- set default_site = "" -%}
+{%- endif -%}
+
 server {
-    listen 80;
-    listen [::]:80;
+    listen 80 {{ default_site }};
+    listen [::]:80 {{ default_site }};
     server_name _;
 
     location '/.well-known/acme-challenge' {

--- a/letsencrypt/templates/nginx/letsencrypt
+++ b/letsencrypt/templates/nginx/letsencrypt
@@ -1,4 +1,4 @@
-{%- if "letsencrypt" in nginx_default_sites -%}
+{%- if nginx_enable_custom_domains -%}
   {%- set default_site = "default_server" -%}
 {%- else -%}
   {%- set default_site = "" -%}

--- a/letsencrypt/templates/nginx/letsencrypt
+++ b/letsencrypt/templates/nginx/letsencrypt
@@ -1,4 +1,4 @@
-{%- if nginx_enable_custom_domains -%}
+{%- if letsencrypt_enable_default_server -%}
   {%- set default_site = "default_server" -%}
 {%- else -%}
   {%- set default_site = "" -%}


### PR DESCRIPTION
If `letsencrypt` is specified in `nginx_default_sites`, it should be there as default_server so that the request for verification when generating a certificate are handled by this nginx config and not the LMS one.