### PR TITLE
Explicitly set the domain names for letsencrypt

### DIFF
--- a/letsencrypt/templates/nginx/letsencrypt
+++ b/letsencrypt/templates/nginx/letsencrypt
@@ -7,7 +7,7 @@
 server {
     listen 80 {{ default_site }};
     listen [::]:80 {{ default_site }};
-    server_name _;
+    server_name {{ letsencrypt_certs | sum(attribute='domains', start=[]) | join(' ') }};
 
     location '/.well-known/acme-challenge' {
         default_type "text/plain";


### PR DESCRIPTION
This is to support enterprise deployments (non-Tahoe), without having to worry about setting extra variables.

For acme challenges, otherwise it keeps 404'ing. Even when I set the following vars for ASU CSET configs (https://github.com/appsembler/edx-configs/pull/177), even when including Filip's #20:

```
letsencrypt_enable_default_server: yes
nginx_enable_custom_domains: "{{ letsencrypt_enable_default_server }"
```


Which [@bezidejni suggested on Slack](https://appsembler.slack.com/archives/G03M0NWL5/p1510125636000111).

---

# TODO

 - [x] Deploy and make sure it still work!
 - [ ] Try to use the `custom_domain_` variables that Filip knows about, instead of this PR (still don't understand it)