### PR TITLE
Make our own certbot cronjob since Ubuntu 16 Aptitude package version won't work with certonly param

### DIFF
--- a/letsencrypt/tasks/main.yml
+++ b/letsencrypt/tasks/main.yml
@@ -82,3 +82,13 @@
     - letsencrypt
     - letsencrypt:configuration
 
+# cron.d/certbot entry from certbot package doesn't work for certonly applications
+- name: Create cron job to renew certificates
+  cron: >
+    name="Let's Encrypt certificate renewal"
+    cron_file="letsencrypt"
+    special_time="daily"
+    user="root"
+    job="{{ letsencrypt_command }} renew --agree-tos"
+  tags:
+    - letsencrypt


### PR DESCRIPTION
The cron entry installed by the Aptitude package doesn't work for our application, so this creates a `letsencrypt` cron job via Ansible.  As far as I know, none of our auto-renew was working, except at least DHIS2 was trying and that's because I _had_ to make our own cron job since Ubuntu 12 didn't have a certbot package

This was the output from what the Apt package installed, and a test using it:
```
root@staging-isc-intersystems-edxapp-0:/home/bryan# sudo cat /etc/cron.d/certbot 
# /etc/cron.d/certbot: crontab entries for the certbot package
#
# Upstream recommends attempting renewal twice a day
#
# Eventually, this will be an opportunity to validate certificates
# haven't been revoked, etc.  Renewal will only occur if expiration
# is within 30 days.
SHELL=/bin/sh
PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin

0 */12 * * * root test -x /usr/bin/certbot -a \! -d /run/systemd/system && perl -e 'sleep int(rand(3600))' && certbot -q renew

root@staging-isc-intersystems-edxapp-0:/home/bryan# /usr/bin/certbot -a \! -d /run/systemd/system && perl -e 'sleep int(rand(3600))' && certbot -q renew
Saving debug log to /var/log/letsencrypt/letsencrypt.log
Certbot doesn't know how to automatically configure the web server on this system. However, it can still get a certificate for you. Please run "certbot certonly" to do so. You'll need to manually configure your web server to use the resulting certificate.
```



