### PR TITLE
Explicitly set permissions for letsencrypt log

### DIFF
--- a/letsencrypt/defaults/main.yml
+++ b/letsencrypt/defaults/main.yml
@@ -3,6 +3,7 @@
 letsencrypt_package: "certbot"
 letsencrypt_command: "certbot"
 letsencrypt_webroot: "/var/www/letsencrypt"
+letsencrypt_logfile: "/var/log/letsencrypt/letsencrypt.log"
 letsencrypt_webuser: "www-data"
 letsencrypt_webserver: "nginx"
 letsencrypt_webserver_config: "nginx/letsencrypt"

--- a/letsencrypt/tasks/main.yml
+++ b/letsencrypt/tasks/main.yml
@@ -53,6 +53,15 @@
   when: letsencrypt_webserver == "nginx"
   tags: ['letsencrypt', 'letsencrypt:configuration']
 
+- name: Set permissions for log file
+  file:
+    path: "{{ letsencrypt_logfile }}"
+    state: touch
+    owner: "{{ letsencrypt_webuser }}"
+    group: "{{ letsencrypt_webuser }}"
+    mode: 0644
+  tags: ['letsencrypt', 'letsencrypt:configuration']
+
 - name: Generate certificates using webroot
   command: >
     {{ letsencrypt_command }} certonly {{ letsencrypt_flags }} --agree-tos -m "{{ letsencrypt_email }}"


### PR DESCRIPTION
Bcuz of manual runs the log permissions becomes incorrect. This ensures that the process is more robust.

BTW, as long as being run via Ansible the log is created automatically via `$ certbot` in the `Generate certificates using webroot` step with correct permissions.