### PR TITLE
Add simple tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,35 @@
+---
+sudo: required
+
+env:
+  - distribution: ubuntu
+    version: xenial
+    ansible: 2.4.3.0
+  - distribution: ubuntu
+    version: xenial
+    ansible: 2.3.1.0
+  - distribution: ubuntu
+    version: trusty
+    ansible: 2.4.3.0
+  - distribution: ubuntu
+    version: trusty
+    ansible: 2.3.1.0
+    
+services:
+  - docker
+
+before_install:
+  - 'sudo docker pull ${distribution}:${version}'
+  - 'sudo docker build --no-cache --rm --file=travis/Dockerfile.${distribution}-${version} --build-arg ansible_version=${ansible} --tag=${distribution}-${version}-${ansible}:ansible travis'
+
+script:
+  - container_id=$(mktemp)
+  - 'sudo docker run --detach --privileged -v /sys/fs/cgroup:/sys/fs/cgroup:ro --volume="${PWD}":/etc/ansible/roles ${distribution}-${version}-${ansible}:ansible > "${container_id}"'
+  - 'sudo docker exec "$(cat ${container_id})" env ANSIBLE_FORCE_COLOR=1 ansible-playbook -v /etc/ansible/roles/tests/test.yml --syntax-check'
+  - 'sudo docker exec "$(cat ${container_id})" env ANSIBLE_FORCE_COLOR=1 ansible-playbook -v /etc/ansible/roles/tests/travis.yml'
+  - >
+    sudo docker exec "$(cat ${container_id})" env ANSIBLE_FORCE_COLOR=1 ansible-playbook -v /etc/ansible/roles/tests/travis.yml
+    | grep -q 'changed=0.*failed=0'
+    && (echo 'Idempotence test: pass' && exit 0)
+    || (echo 'Idempotence test: fail' && exit 1)
+  - 'sudo docker rm -f "$(cat ${container_id})"'

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,7 @@
-.PHONY = docs-serve docs-build
+.PHONY = docs-serve docs-build syntax-check
+
+syntax-check:
+	@ansible-playbook -i tests/inventory --syntax-check tests/test.yml
 
 # =========== MkDocs ================= #
 docs-serve:

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/appsembler/roles.svg?branch=develop)](https://travis-ci.org/appsembler/roles)
+
 # Ansible Roles
 
 The purpose of this repository is to collect general-purpose Ansible roles with a focus on sane defaults,
@@ -24,3 +26,17 @@ Roles that live in this repo should be general enough to be reused across multip
 
 
 [best-practices]: https://github.com/appsembler/roles/tree/develop/docs/best-practices.md
+
+
+## Testing
+
+At the very least, you should run a syntax check locally:
+
+    $ make syntax-check
+
+The repo is configured to run some basic tests on TravisCI. It runs
+them on Ubuntu 14.04 and 16.04 systems with different ansible
+versions, just checking that the roles can be applied without errors
+and that they are idempotent.
+
+(TODO: document how to run these tests locally)

--- a/tests/inventory
+++ b/tests/inventory
@@ -1,0 +1,1 @@
+localhost

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -1,0 +1,16 @@
+---
+- hosts: localhost
+  remote_user: root
+  roles:
+    - cert_agent
+    - consul_template
+    - gcsfuse
+    - incron
+    - letsencrypt
+    - logstash
+    - monit
+    - openjdk
+    - ossec
+    - sftp
+    - snort
+    - stackdriver

--- a/tests/travis.yml
+++ b/tests/travis.yml
@@ -1,0 +1,6 @@
+---
+- hosts: localhost
+  remote_user: root
+  roles:
+    - gcsfuse
+    - incron

--- a/travis/Dockerfile.ubuntu-trusty
+++ b/travis/Dockerfile.ubuntu-trusty
@@ -1,0 +1,21 @@
+FROM ubuntu:trusty
+
+RUN apt-get update && apt-get dist-upgrade -y && apt-get install -y software-properties-common && rm -rf /var/lib/apt/lists/*
+
+RUN apt-get update && apt-get install -y \
+    git \
+		libffi-dev \
+		libssl-dev \
+		python-dev \
+		python-pip \
+		python-virtualenv \
+ && rm -rf /var/lib/apt/lists/*
+
+ARG ansible_version=2.4.3.0
+
+RUN pip install setuptools -U
+RUN pip install ansible==${ansible_version}
+RUN mkdir /etc/ansible/
+RUN echo "[local]\nlocalhost ansible_connection=local" > /etc/ansible/hosts
+
+ENTRYPOINT ["/sbin/init"]

--- a/travis/Dockerfile.ubuntu-xenial
+++ b/travis/Dockerfile.ubuntu-xenial
@@ -1,0 +1,18 @@
+FROM ubuntu:xenial
+
+RUN apt-get update && apt-get dist-upgrade -y && apt-get install -y software-properties-common && rm -rf /var/lib/apt/lists/*
+
+RUN apt-get update && apt-get install -y \
+    git \
+		python-dev \
+		python-pip \
+		python-virtualenv \
+ && rm -rf /var/lib/apt/lists/*
+ 
+ARG ansible_version=2.4.3.0
+
+RUN pip install ansible==${ansible_version}
+RUN mkdir /etc/ansible/
+RUN echo "[local]\nlocalhost ansible_connection=local" > /etc/ansible/hosts
+
+ENTRYPOINT ["/sbin/init"]


### PR DESCRIPTION
Ansible roles need tests too :)

This sets up a simple testing framework to start with:

* you can now run `make syntax-check` to get a quick syntax check
* TravisCI is enabled and attempts to install the roles on Ubuntu 14.04 and 16.04 instances using ansible 2.4 and 2.3. Then it re-runs the install to check for idempotency violations.

Obviously, this is not very thorough testing. I'm just trying to get something in place so we can add more as we go.

Notes/questions:

* I'd like to get other ansible versions included as well. I tried with 2.2.0.0 (which ficus uses), but there were idempotency problems there. I will dig into those later and see if I can get it added later.
* Do we care about any other OS versions? I know there are still some 12.04 machines out there but I don't think it's a priority to keep our roles tested against that.
* I had to skip a number of roles for the full tests (only a couple are in `tests/travis.yml`). The skipped ones all had errors that I need to look into separately. Once I have a chance to debug those individually, I'll add them back in.
* Eventually we can also add, like, actual tests for the functionality of the roles. Right now it basically passes if they can be run without error, but it's not hard to imagine doing some checks on the container and asserting that services we expect to be running are running, etc.