### PR TITLE
test against ansible 2.5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 site/
 /.idea/
+tests/travis.retry

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,9 @@ env:
     ansible: 2.4.3.0
   - distribution: ubuntu
     version: xenial
+    ansible: 2.5.0rc3
+  - distribution: ubuntu
+    version: xenial
     ansible: 2.3.1.0
   - distribution: ubuntu
     version: trusty


### PR DESCRIPTION
Get ready for the future.

I don't think it's worth it to run the ansible 2.5 tests on Trusty. I imagine that when we actually get to the point of using ansible 2.5, we won't be doing it against anything older than Xenial.