### PR TITLE
Template consul template (instead of copy)

### DIFF
--- a/consul_template/tasks/main.yml
+++ b/consul_template/tasks/main.yml
@@ -32,7 +32,7 @@
   tags: ['consul_template', 'consul_template:configuration']
 
 - name: Copy template files
-  copy: >
+  template: >
     src="{{ item }}" dest="{{ consul_template_template_dir }}/{{ item | basename }}"
   notify: restart consul-template
   with_items: "{{ consul_template_templates }}"


### PR DESCRIPTION
Just a small change that allows us to template the config file for consul-template. The version of this repo/submodule is pinned in the Wharf repo so merging this won't break anything.