### PR TITLE
ignore .retry files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 site/
 /.idea/
+*.retry


### PR DESCRIPTION
When testing locally, ansible likes to create files like `tests/travis.retry`. Let's just ignore those.