### PR TITLE
Support LetsEncrypt renew during Ansible provision

### DIFF
--- a/letsencrypt/README.md
+++ b/letsencrypt/README.md
@@ -1,0 +1,11 @@
+# The LetsEncrypt Role
+This document serves as a lightweight note about the role and its maintainance.
+
+
+## Version Pinning for Certbot
+Unlike `$ pip`, `$ apt-get` doesn't support versioning pretty well, so version pins will usually break
+as the maintainers can (and usually do) remove the old packages from their debian package repositories.
+
+That being said, having a missing dependency will make Ansible complain and that will make it clear for us.
+We'll amend our playbook. Otherwise we're risking feature deprecation and having new funcitonality sneak in without
+notice which probably what caused the multiple SSL renewals failures in late 2017 to early 2018.

--- a/letsencrypt/defaults/main.yml
+++ b/letsencrypt/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 
-letsencrypt_package: "certbot"
+letsencrypt_package: "certbot=0.22.*"  # Pin to prevent major updates (more in letsencrypt/README.md)
 letsencrypt_command: "certbot"
 letsencrypt_certbot_plugin: "webroot"
 letsencrypt_webroot: "/var/www/letsencrypt"

--- a/letsencrypt/tasks/main.yml
+++ b/letsencrypt/tasks/main.yml
@@ -60,7 +60,7 @@
     owner: "{{ letsencrypt_webuser }}"
     group: "{{ letsencrypt_webuser }}"
     mode: 0644
-  tags: ['letsencrypt', 'letsencrypt:configuration']
+  tags: ['letsencrypt', 'letsencrypt:configuration', 'letsencrypt:renew']
 
 - name: Create target hook script directory
   file: path=/opt/scripts state=directory mode=0755
@@ -89,6 +89,30 @@
   run_once: true
   when: letsencrypt_run|bool == true and letsencrypt_certbot_plugin == "webroot"
   tags: ['letsencrypt', 'letsencrypt:run']
+
+- name: Renew the webroot certificate if needed
+  # certbot is smart enough to renew only when needed
+  # This task is useful till we solve the LetsEncrypt cronjob issue
+  command: >
+    {{ letsencrypt_command }} renew --cert-name {{ item.domains[0] }}
+  with_items: "{{ letsencrypt_certs }}"
+  become: True
+  become_user: "{{ letsencrypt_webuser }}"
+  when:
+    - letsencrypt_run|bool == true
+    - letsencrypt_certbot_plugin == "webroot"
+  tags: ['letsencrypt', 'letsencrypt:run', 'letsencrypt:renew']
+
+- name: Reload nginx
+  # Reload nginx one more time just in case a certificate was renewed
+  # TODO: (Omar) This is probably useless due to `certbot_override.conf`,
+  #       but we're having too many issues right now in this role to try to worry about optimizing out a single reload.
+  service: name=nginx state=reloaded
+  when:
+    - letsencrypt_run|bool == true
+    - letsencrypt_certbot_plugin == "webroot"
+    - letsencrypt_webserver == "nginx"
+  tags: ['letsencrypt', 'letsencrypt:run', 'letsencrypt:renew']
 
 - name: Generate certificates manually
   command: >

--- a/letsencrypt/tasks/main.yml
+++ b/letsencrypt/tasks/main.yml
@@ -75,7 +75,12 @@
 
 - name: Generate certificates using webroot
   command: >
-    {{ letsencrypt_command }} certonly {{ letsencrypt_flags }} --agree-tos -m "{{ letsencrypt_email }}" --webroot -w "{{ letsencrypt_webroot }}" -d {{ item.domains | join(' -d ') }}
+    {{ letsencrypt_command }} certonly {{ letsencrypt_flags }}
+    --agree-tos
+    --email "{{ letsencrypt_email }}"
+    --webroot
+    --webroot-path "{{ letsencrypt_webroot }}"
+    --domains {{ item.domains | join(' --domains ') }}
   args:
     creates: /etc/letsencrypt/live/{{ item.domains[0] }}/fullchain.pem
   with_items: "{{ letsencrypt_certs }}"


### PR DESCRIPTION
Because `name: Generate certificates using webroot` only works once in a server life time. 

This is due to `creates: /etc/letsencrypt/live/{{ item.domains[0] }}/fullchain.pem`. Unless you manually delete the `.pem` file or change the domain, it shouldn't run again.

### TODO
 - [x] Deploy on a server and test it -- done with NewHorizons

### Reviewers
 - @bryanlandia more detailed review.
 - @thraxil If you're curious.
 - @melvinsoft for a light review to ensure we're not breaking anything for Tahoe.
 - @bezidejni for a light review to ensure we're not breaking anything for Blue Team.
