### PR TITLE
Fix certbot cronjob and add checks for the LetsEncrypt role to keep developer's sanity

### DIFF
--- a/letsencrypt/README.md
+++ b/letsencrypt/README.md
@@ -1,11 +1,49 @@
 # The LetsEncrypt Role
-This document serves as a lightweight note about the role and its maintainance.
+This document serves as a lightweight note about the role and its maintenance.
 
+## How to Use this Role with Open edX
+This role is primarily used for Open edX deployments,
+but is generic enough to be used for other Debian based 
+systems that use Nginx.
+
+This role is included in our deployment playbooks like
+[`ficus_basic.yml`](https://github.com/appsembler/configuration/blob/appsembler/ficus/master/playbooks/appsemblerPlaybooks/ficus_basic.yml)
+and 
+[`ginkgo_enterprise.yml`](https://github.com/appsembler/configuration/blob/appsembler/ginkgo/master/playbooks/appsemblerPlaybooks/ginkgo_enterprise.yml).
+
+So usually it will be run without intervention. However, in some cases we need to run this role only.
+Below are few examples on how to use it.
+
+**Note:** Run via `$ ax` instead of `$ ansible-playbook` for Appsembler deployments.
+
+### Run the LetsEncrypt Role
+To run all the tasks (except for renew tasks):
+
+```
+$ ansible-playbook --tags=letsencrypt ficus_basic.yml
+```
+
+### Manually Renew the Certs
+When necessary, a manual renew can be done by adding the `letsencrypt:renew` tag.
+
+```
+$ ansible-playbook --tags=letsencrypt,letsencrypt:renew ficus_basic.yml
+```
+
+For a quicker run, the `letsencrypt:renew` tags can be used separately:
+
+```
+$ ansible-playbook --tags=letsencrypt:renew ficus_basic.yml
+```
 
 ## Version Pinning for Certbot
-Unlike `$ pip`, `$ apt-get` doesn't support versioning pretty well, so version pins will usually break
+Unlike `$ pip`, `$ apt-get` does not support versioning pretty well, so version pins will usually break
 as the maintainers can (and usually do) remove the old packages from their debian package repositories.
 
-That being said, having a missing dependency will make Ansible complain and that will make it clear for us.
-We'll amend our playbook. Otherwise we're risking feature deprecation and having new funcitonality sneak in without
+That being said, having a missing dependency will make Ansible complain and that will make it clear for
+the engineer who is deploying the server.
+
+Once a version gone missing the LetsEncrypt playbook should be amended. 
+
+Otherwise we're risking feature deprecation and having new functionality sneak in without
 notice which probably what caused the multiple SSL renewals failures in late 2017 to early 2018.

--- a/letsencrypt/defaults/main.yml
+++ b/letsencrypt/defaults/main.yml
@@ -1,6 +1,12 @@
 ---
 
-letsencrypt_package: "certbot=0.22.*"  # Pin to prevent major updates (more in letsencrypt/README.md)
+# Pin to prevent unintentional updates (more in letsencrypt/README.md)
+
+# Note: The trailing `-*` is to match the rather verbose package
+#       versions in Debian e.g. `0.22.2-1+ubuntu16.04.1+certbot+1`
+letsencrypt_package: "certbot={{ letsencyrpt_version }}-*"
+letsencyrpt_version: "0.22.2"
+
 letsencrypt_command: "certbot"
 letsencrypt_certbot_plugin: "webroot"
 letsencrypt_webroot: "/var/www/letsencrypt"

--- a/letsencrypt/files/certbot_override.conf
+++ b/letsencrypt/files/certbot_override.conf
@@ -1,3 +1,0 @@
-[Service]
-ExecStartPost=/bin/systemctl reload nginx.service
-

--- a/letsencrypt/tasks/main.yml
+++ b/letsencrypt/tasks/main.yml
@@ -8,7 +8,9 @@
     - letsencrypt:install
 
 - name: Install Let's Encrypt
-  apt: name="{{ letsencrypt_package }}"
+  apt:
+    name: "{{ letsencrypt_package }}"
+    update_cache: yes
   tags: ['letsencrypt', 'letsencrypt:install']
 
 - name: Create Let's Encrypt directories
@@ -33,12 +35,62 @@
   become_user: "{{ letsencrypt_webuser }}"
   tags: ['letsencrypt', 'letsencrypt:configuration']
 
+- name: Count the number of certbot installations
+  shell: whereis {{ letsencrypt_command }} | grep -w -o '/[^ ]*bin/[^ ]*{{ letsencrypt_command }}' | wc -l
+  register: certbot_count_call
+  become: True
+  become_user: root
+  tags:
+    - letsencrypt
+    - letsencrypt:configuration
+    - letsencrypt:check
+
+- fail:
+    msg: There's more than one certbot installation
+    # Login to the server and run: `$ whereis certbot`.
+    # Unfortunately, there's no clear way to solve this issue, so try to solve it manually. Suggestion:
+    #   - `$ sudo apt-get purge certbot`
+    #   - `$ sudo pip uninstall certbot`
+    #   - If there's another `$ which certbot`, uninstall it.
+    #   - Re-run this playbook
+  when: certbot_count_call.stdout != "1"
+  tags:
+    - letsencrypt
+    - letsencrypt:configuration
+    - letsencrypt:check
+
+- name: Get the certbot version
+  shell: certbot --version 2>&1 | cut -d ' ' -f 2
+  register: certbot_version_call
+  become: True
+  become_user: root
+  tags:
+    - letsencrypt
+    - letsencrypt:configuration
+    - letsencrypt:check
+
+- fail:
+    msg: >
+      An installed certbot version on the server
+      ({{ certbot_version_call.stdout }}) do not match the required
+      ({{ letsencyrpt_version }}) by the playbook
+    # Login to the server and run: `$ pip freeze | grep certbot`.
+    # Unfortunately, there's no clear way to solve this issue, look at `certbot_count_call` above.
+  when: certbot_version_call.stdout is version_compare(letsencyrpt_version, operator='ne', strict=True)
+  tags:
+    - letsencrypt
+    - letsencrypt:configuration
+    - letsencrypt:check
+
 - name: Copy nginx config
   template:
     src: "{{ letsencrypt_webserver_config }}"
     dest: "{{ letsencrypt_webserver_sites_available }}/{{ letsencrypt_webserver_config | basename }}"
   when: letsencrypt_webserver == "nginx"
-  tags: ['letsencrypt', 'letsencrypt:configuration']
+  tags:
+    - letsencrypt
+    - letsencrypt:configuration
+    - letsencrypt:nginx
 
 - name: Enable nginx config
   file:
@@ -46,21 +98,31 @@
     path: "{{ letsencrypt_webserver_sites_enabled }}/{{ letsencrypt_webserver_config | basename }}"
     src: "{{ letsencrypt_webserver_sites_available }}/{{ letsencrypt_webserver_config | basename }}"
   when: letsencrypt_webserver == "nginx"
-  tags: ['letsencrypt', 'letsencrypt:configuration']
+  tags:
+    - letsencrypt
+    - letsencrypt:configuration
+    - letsencrypt:nginx
 
 - name: Reload nginx
   service: name=nginx state=reloaded
   when: letsencrypt_webserver == "nginx"
-  tags: ['letsencrypt', 'letsencrypt:configuration']
+  tags:
+    - letsencrypt
+    - letsencrypt:configuration
+    - letsencrypt:nginx
 
-- name: Set permissions for log file
+- name: Set permissions for log file and ensure it exists
   file:
     path: "{{ letsencrypt_logfile }}"
     state: touch
     owner: "{{ letsencrypt_webuser }}"
     group: "{{ letsencrypt_webuser }}"
     mode: 0644
-  tags: ['letsencrypt', 'letsencrypt:configuration', 'letsencrypt:renew']
+  tags:
+    - letsencrypt
+    - letsencrypt:run
+    - letsencrypt:configuration
+    - letsencrypt:renew
 
 - name: Create target hook script directory
   file: path=/opt/scripts state=directory mode=0755
@@ -85,7 +147,7 @@
     creates: /etc/letsencrypt/live/{{ item.domains[0] }}/fullchain.pem
   with_items: "{{ letsencrypt_certs }}"
   become: True
-  become_user: "{{ letsencrypt_webuser }}"
+  become_user: root
   run_once: true
   when: letsencrypt_run|bool == true and letsencrypt_certbot_plugin == "webroot"
   tags: ['letsencrypt', 'letsencrypt:run']
@@ -97,22 +159,23 @@
     {{ letsencrypt_command }} renew --cert-name {{ item.domains[0] }}
   with_items: "{{ letsencrypt_certs }}"
   become: True
-  become_user: "{{ letsencrypt_webuser }}"
+  become_user: root
   when:
     - letsencrypt_run|bool == true
     - letsencrypt_certbot_plugin == "webroot"
-  tags: ['letsencrypt', 'letsencrypt:run', 'letsencrypt:renew']
+  tags:
+    - letsencrypt:renew  # More on letsencrypt/README.md
 
 - name: Reload nginx
   # Reload nginx one more time just in case a certificate was renewed
-  # TODO: (Omar) This is probably useless due to `certbot_override.conf`,
-  #       but we're having too many issues right now in this role to try to worry about optimizing out a single reload.
   service: name=nginx state=reloaded
   when:
     - letsencrypt_run|bool == true
     - letsencrypt_certbot_plugin == "webroot"
     - letsencrypt_webserver == "nginx"
-  tags: ['letsencrypt', 'letsencrypt:run', 'letsencrypt:renew']
+  tags:
+    - letsencrypt:renew  # More on letsencrypt/README.md
+    - letsencrypt:nginx
 
 - name: Generate certificates manually
   command: >
@@ -121,23 +184,34 @@
     creates: /etc/letsencrypt/live/{{ item.domains[0] }}/fullchain.pem
   with_items: "{{ letsencrypt_certs }}"
   become: True
-  become_user: "{{ letsencrypt_webuser }}"
+  become_user: root
   run_once: true
   when: letsencrypt_run|bool == true and letsencrypt_certbot_plugin == "manual"
   tags: ['letsencrypt', 'letsencrypt:run']
 
-- name: Make sure certbot systemd override dir exists
-  file: path=/etc/systemd/system/certbot.service.d state=directory
+- name: Remove legacy certbot.conf
+  # Earlier this role used to create that file, but now it is useless
+  file:
+    path: /etc/systemd/system/certbot.service.d/certbot.conf
+    state: absent
   tags:
     - letsencrypt
     - letsencrypt:configuration
 
-- name: Make sure to restart service on certbot/ssl renewal
-  copy:
-    src=certbot_override.conf
-    dest=/etc/systemd/system/certbot.service.d/certbot.conf
-  notify:
-    - reload systemd configuration
+- name: Create an additional cron job to renew certificates
+  # cron.d/certbot entry from certbot package doesn't work for for Ubuntu 16.04 because of systemd directory exists
+  # We still don't know why such a problem exists, becasue systemd is supposed to run certbot instead.
+  #
+  # Anyway this additional cronjob solve the problem, and running renew twice should be harmless.
+  cron:
+    name: "Let's Encrypt certificate renewal"
+    cron_file: certbot_appsembler
+    special_time: daily
+    user: root
+    # `>` makes it into a single line. The line-break is for developer readability.
+    # The `sleep()` is recommended by certbot to avoid effectively bombarding their servers at the same time
+    job: >
+      perl -e 'sleep int(rand(3600))' &&
+      {{ letsencrypt_command }} renew --agree-tos --post-hook='service nginx reload'
   tags:
     - letsencrypt
-    - letsencrypt:configuration


### PR DESCRIPTION
Major refactoring for the LetsEncrypt role to fix the bugging issues in its renew process: ![](https://github.trello.services/images/mini-trello-icon.png) [(8) Fix the cronjob issue with LetsEncrypt](https://trello.com/c/3cePOzCF/2746-8-fix-the-cronjob-issue-with-letsencrypt). This PR fixes #28.

## Overview
`certbot` cronjob thinks that `systemd` will do the scheduling, but systemd seems not to be configured to run `$ certbot`. We used a custom cronjob and solved the issue.

## Major Changes
 - Include and refactor Appsembler's cronjob: https://github.com/appsembler/roles/pull/26
 - Require exact `$ certbot` `apt` and `pip` package versions with sanity checks on them.
 - Expliclity fail if there are more than one `$ certbot` binary was found.

## Other Changes
 - Docs
 - Use `become_user: root` instead of `become_user: "{{ letsencrypt_webuser }}"` to match what `$ certbot` does in it's cronjob by default (see :point_down:):
 - Remove legacy certbot.conf

## Testing
 - [x] Test on John's server: [Auto-renewed John's expiring certificates overnight](https://trello.com/c/3cePOzCF/2746-8-fix-the-cronjob-issue-with-letsencrypt#comment-5ad967eb7a063870a42f058c).
 - [x] Test on Epic: Waiting for their next MW.

## Reviews
 I this we should have one reviewer from every team, because this PR impacts all teams:

 - [x] A Black Team engineer
 - [x] A Red Team engineer
 - [x] A Blue Team engineer
 - [x] All the Engineers in Green Team :wink: 

-----

## Certbot Provided Cronjob
The certbot provided cronjob never run, because Ubuntu 16.04 has the directory `/run/systemd/system`, and certbot cronjob won't run -- by design.

```
ubuntu@prod-epic-mlp-edxapp-0:~$ sudo cat /etc/cron.d/certbot
# /etc/cron.d/certbot: crontab entries for the certbot package
#
# Upstream recommends attempting renewal twice a day
#
# Eventually, this will be an opportunity to validate certificates
# haven't been revoked, etc.  Renewal will only occur if expiration
# is within 30 days.
SHELL=/bin/sh
PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin

0 */12 * * * root test -x /usr/bin/certbot -a \! -d /run/systemd/system && perl -e 'sleep int(rand(3600))' && certbot renew --agree-tos
````

