### PR TITLE
Make consul template command optional

### DIFF
--- a/consul_template/defaults/main.yml
+++ b/consul_template/defaults/main.yml
@@ -16,7 +16,7 @@ consul_template_rendered_dir: "/etc/consul-template/rendered"
 
 # Options for the default configuration file
 consul_template_consul: "consul.service.consul:8500"
-consul_template_command: "/bin/true"
+consul_template_command: ""
 
 # Extra options to pass to `docker run` when starting the systemd service
 consul_template_docker_options: ""

--- a/consul_template/templates/consul-template.conf
+++ b/consul_template/templates/consul-template.conf
@@ -4,6 +4,6 @@ consul = "{{ consul_template_consul }}"
 template {
     source = "{{ consul_template_template_dir }}/{{ t | basename }}"
     destination = "/etc/consul-template/rendered/{{ t | basename }}"
-    command = "{{ consul_template_command }}"
+    {% if consul_template_command %}command = "{{ consul_template_command }}"{% endif %}
 }
 {% endfor %}


### PR DESCRIPTION
On several wharf servers, potentially connected to upgrading of consul-template image, I've been getting errors like these in the logs:

```
Jun 22 17:10:22 staging-appsembler-wharf-0 docker[20194]: 2018/06/22 17:10:22.838711 [ERR] (cli) 1 error occurred:
Jun 22 17:10:22 staging-appsembler-wharf-0 docker[20194]: * failed to execute command "/bin/true" from "/etc/consul-template/templates/containers.conf" => "/etc/consul-template/rend
Jun 22 17:10:23 staging-appsembler-wharf-0 systemd[1]: consul-template.service: Main process exited, code=exited, status=14/n/a
Jun 22 17:10:23 staging-appsembler-wharf-0 docker[20580]: consul-template
Jun 22 17:10:23 staging-appsembler-wharf-0 systemd[1]: consul-template.service: Unit entered failed state.
Jun 22 17:10:23 staging-appsembler-wharf-0 systemd[1]: consul-template.service: Failed with result 'exit-code'.
Jun 22 17:10:23 staging-appsembler-wharf-0 systemd[1]: consul-template.service: Service hold-off time over, scheduling restart.
Jun 22 17:10:23 staging-appsembler-wharf-0 systemd[1]: Stopped Consul Template.
Jun 22 17:10:23 staging-appsembler-wharf-0 systemd[1]: Starting Consul Template...
```

It seems that the consul-template image doesn't contain `/bin/true` (confirmed by trying to do `docker exec`) and it causes the consul-template service to fail, stop and get restarted. From [consul-template docs](https://github.com/hashicorp/consul-template#configuration-file-format), it says: 

> "This is the optional command to run when the template is rendered. The command will only run if the resulting template changes. The command must return within 30s (configurable), and it must have a successful exit code. Consul Template is not a replacement for a process monitor or init system."

So we don't really need a default command but should still allow customizing if needed.