### PR TITLE
bump letsencrypt version to 0.25.0

### DIFF
--- a/letsencrypt/defaults/main.yml
+++ b/letsencrypt/defaults/main.yml
@@ -5,7 +5,7 @@
 # Note: The trailing `-*` is to match the rather verbose package
 #       versions in Debian e.g. `0.22.2-1+ubuntu16.04.1+certbot+1`
 letsencrypt_package: "certbot={{ letsencyrpt_version }}-*"
-letsencyrpt_version: "0.22.2"
+letsencyrpt_version: "0.25.0"
 
 letsencrypt_command: "certbot"
 letsencrypt_certbot_plugin: "webroot"

--- a/letsencrypt/defaults/main.yml
+++ b/letsencrypt/defaults/main.yml
@@ -4,8 +4,8 @@
 
 # Note: The trailing `-*` is to match the rather verbose package
 #       versions in Debian e.g. `0.22.2-1+ubuntu16.04.1+certbot+1`
-letsencrypt_package: "certbot={{ letsencyrpt_version }}-*"
-letsencyrpt_version: "0.25.0"
+letsencrypt_package: "certbot={{ letsencrypt_version }}-*"
+letsencrypt_version: "0.25.0"
 
 letsencrypt_command: "certbot"
 letsencrypt_certbot_plugin: "webroot"

--- a/letsencrypt/tasks/main.yml
+++ b/letsencrypt/tasks/main.yml
@@ -73,10 +73,10 @@
     msg: >
       An installed certbot version on the server
       ({{ certbot_version_call.stdout }}) do not match the required
-      ({{ letsencyrpt_version }}) by the playbook
+      ({{ letsencrypt_version }}) by the playbook
     # Login to the server and run: `$ pip freeze | grep certbot`.
     # Unfortunately, there's no clear way to solve this issue, look at `certbot_count_call` above.
-  when: certbot_version_call.stdout is version_compare(letsencyrpt_version, operator='ne', strict=True)
+  when: certbot_version_call.stdout is version_compare(letsencrypt_version, operator='ne', strict=True)
   tags:
     - letsencrypt
     - letsencrypt:configuration


### PR DESCRIPTION
0.22.2 is no longer in the apt repo (at least on Tahoe 16.04 servers), so it fails when attempting to update.