### PR TITLE
Allow setting gunicorn timeout

### DIFF
--- a/cert_agent/defaults/main.yml
+++ b/cert_agent/defaults/main.yml
@@ -18,6 +18,7 @@ cert_agent_gunicorn_runtime_dir_name: cert_agent
 cert_agent_gunicorn_pid: "/run/{{ cert_agent_gunicorn_runtime_dir_name }}/pid"
 cert_agent_gunicorn_bind_ip: "0.0.0.0"
 cert_agent_gunicorn_port: "18000"
+cert_agent_gunicorn_timeout: "30"
 
 cert_agent_ansible_cmd: "cd /edx/app/edx_ansible/edx_ansible/playbooks && ../../venvs/edx_ansible/bin/ansible-playbook -i ../../app_nodes_inventory --extra-vars '@../../server-vars.yml' --tags=sudo,custom_domains,letsencrypt:run,nginx:custom_domains amc.yml"
 
@@ -32,4 +33,3 @@ cert_agent_django_env_vars: {
 }
 
 cert_agent_ssh_private_key: "changeme"
-

--- a/cert_agent/templates/cert_agent.service
+++ b/cert_agent/templates/cert_agent.service
@@ -11,7 +11,8 @@ RuntimeDirectory={{ cert_agent_gunicorn_runtime_dir_name }}
 ExecStart={{ cert_agent_venv_dir }}/bin/gunicorn --pid {{ cert_agent_gunicorn_pid }} \
           --bind {{ cert_agent_gunicorn_bind_ip }}:{{ cert_agent_gunicorn_port }} \
           -w 3 \
-          cert_agent.wsgi:application
+          cert_agent.wsgi:application \
+          --timeout {{ cert_agent_gunicorn_timeout }}
 ExecReload=/bin/kill -s HUP $MAINPID
 ExecStop=/bin/kill -s TERM $MAINPID
 PrivateTmp=true


### PR DESCRIPTION
By default Gunicorn timeout is 30 seconds, that isn't enough for the custom domains generation process. This PR adds the variable to the service definition, we keep 30 sec in the default, but we're increasing this a lot in the companion edx-configs PR: https://github.com/appsembler/edx-configs/pull/416