### PR TITLE
bump letsencrypt version to 0.26.1

### DIFF
--- a/letsencrypt/defaults/main.yml
+++ b/letsencrypt/defaults/main.yml
@@ -5,7 +5,7 @@
 # Note: The trailing `-*` is to match the rather verbose package
 #       versions in Debian e.g. `0.22.2-1+ubuntu16.04.1+certbot+1`
 letsencrypt_package: "certbot={{ letsencrypt_version }}-*"
-letsencrypt_version: "0.25.0"
+letsencrypt_version: "0.26.1"
 
 letsencrypt_command: "certbot"
 letsencrypt_certbot_plugin: "webroot"


### PR DESCRIPTION
Once again, the previous version we were on is no longer in the apt repos, so we get:

```
TASK [../../appsembler-roles/letsencrypt : Install Let's Encrypt] **************
fatal: [104.196.143.123]: FAILED! => {"cache_update_time": 1540372642, "cache_updated": false, "changed": false, "failed": true, "msg": "'/usr/bin/apt
-get -y -o \"Dpkg::Options::=--force-confdef\" -o \"Dpkg::Options::=--force-confold\"     install 'certbot=0.25.0-*'' failed: E: Version '0.25.0-*' fo
r 'certbot' was not found\n", "stderr": "E: Version '0.25.0-*' for 'certbot' was not found\n", "stdout": "Reading package lists...\nBuilding dependenc
y tree...\nReading state information...\n", "stdout_lines": ["Reading package lists...", "Building dependency tree...", "Reading state information..."
]}```