### PR TITLE
configure statsd settings for cert_agent

### DIFF
--- a/cert_agent/defaults/main.yml
+++ b/cert_agent/defaults/main.yml
@@ -23,6 +23,10 @@ cert_agent_gunicorn_timeout: "30"
 
 cert_agent_ansible_cmd: "cd /edx/app/edx_ansible/edx_ansible/playbooks && ../../venvs/edx_ansible/bin/ansible-playbook -i ../../app_nodes_inventory --extra-vars '@../../server-vars.yml' --tags=sudo,custom_domains,letsencrypt:run,nginx:custom_domains amc.yml"
 
+cert_agent_statsd_host: 'stage-prometheus.infra.appsembler.com'
+cert_agent_statsd_port: 9125
+cert_agent_statsd_prefix: 'tahoe_cert_agent'
+
 cert_agent_django_env_vars: {
   API_SECRET_KEY: "{{cert_agent_api_secret_key}}",
   DJANGO_DEBUG: "{{cert_agent_django_debug}}",
@@ -32,6 +36,9 @@ cert_agent_django_env_vars: {
   ANSIBLE_CMD: "{{ cert_agent_ansible_cmd }}",
   DJANGO_LOG_LEVEL: "DEBUG",
   ANSIBLE_LOG_DIR: "{{ cert_agent_log_directory }}",
+  STATSD_HOST: "{{ cert_agent_statsd_host }}",
+  STATSD_PORT: "{{ cert_agent_statsd_port }}",
+  STATSD_PREFIX: "{{ cert_agent_statsd_prefix }}",
 }
 
 cert_agent_ssh_private_key: "changeme"


### PR DESCRIPTION
allow the various statsd environment variables to be set via ansible. Mostly, this is so we can set the `STATSD_HOST` correctly in production.