### PR TITLE
add fluentd config files for more services

### DIFF
--- a/google-fluentd/templates/apt_history.conf
+++ b/google-fluentd/templates/apt_history.conf
@@ -1,0 +1,19 @@
+<source>
+  @type tail
+
+  # sample:
+  # Start-Date: 2019-03-02  06:32:52
+  # Commandline: /usr/bin/unattended-upgrade
+  # Upgrade: libgd3:amd64 (2.1.1-4ubuntu0.16.04.10, 2.1.1-4ubuntu0.16.04.11)
+  # End-Date: 2019-03-02  06:33:02
+  
+  format multiline
+  format_firstline /Start-Date/
+  format1 /^Start\-Date: (?<time>\d{4}-\d{1,2}-\d{1,2}\s+\d{1,2}:\d{1,2}:\d{1,2})(?<message>.*)/
+
+  path /var/log/apt/history.log
+  pos_file /var/lib/google-fluentd/pos/apt-history.pos
+  read_from_head true
+  tag apt-history
+</source>
+

--- a/google-fluentd/templates/authlog.conf
+++ b/google-fluentd/templates/authlog.conf
@@ -1,0 +1,11 @@
+<source>
+  @type tail
+
+  # Parse the timestamp, but still collect the entire line as 'message'
+  format /^(?<message>(?<time>[^ ]*\s*[^ ]* [^ ]*) .*)$/
+
+  path /var/log/auth.log
+  pos_file /var/lib/google-fluentd/pos/authlog.pos
+  read_from_head true
+  tag authlog
+</source>

--- a/google-fluentd/templates/edx_edxapp.conf
+++ b/google-fluentd/templates/edx_edxapp.conf
@@ -1,0 +1,22 @@
+<source>
+  @type tail
+
+  # Parse the timestamp, but still collect the entire line as 'message'
+  format /^(?<message>(?<time>[^ ]*\s*[^ ]* [^ ]*) .*)$/
+
+  path /edx/var/log/lms/edx.log
+  pos_file /var/lib/google-fluentd/pos/edx-edxapp-lms.pos
+  read_from_head true
+  tag edx-edxapp-lms
+</source>
+<source>
+  @type tail
+
+  # Parse the timestamp, but still collect the entire line as 'message'
+  format /^(?<message>(?<time>[^ ]*\s*[^ ]* [^ ]*) .*)$/
+
+  path /edx/var/log/cms/edx.log
+  pos_file /var/lib/google-fluentd/pos/edx-edxapp-cms.pos
+  read_from_head true
+  tag edx-edxapp-cms
+</source>

--- a/google-fluentd/templates/edx_nginx_json.conf
+++ b/google-fluentd/templates/edx_nginx_json.conf
@@ -1,0 +1,40 @@
+
+<source>
+  @type tail
+  format json
+  time_key time_local
+  time_format "%iso8601"
+  path /edx/var/log/nginx/access_json.log
+  pos_file /var/lib/google-fluentd/pos/edx-nginx-json-access.pos
+  read_from_head true
+  tag nginx-json-access
+</source>
+<source>
+  @type tail
+  format json
+  time_key time_local
+  time_format "%iso8601"
+  path /edx/var/log/nginx/access_lms_json.log
+  pos_file /var/lib/google-fluentd/pos/edx-nginx-lms-json-access.pos
+  read_from_head true
+  tag nginx-json-lms-access
+</source>
+<source>
+  @type tail
+  format json
+  time_key time_local
+  time_format "%iso8601"
+  path /edx/var/log/nginx/access_cms_json.log
+  pos_file /var/lib/google-fluentd/pos/edx-nginx-cms-json-access.pos
+  read_from_head true
+  tag nginx-json-cms-access
+</source>
+
+<source>
+  @type tail
+  format none
+  path /edx/var/log/nginx/error.log
+  pos_file /var/lib/google-fluentd/pos/edx-nginx-error.pos
+  read_from_head true
+  tag nginx-error
+</source>

--- a/google-fluentd/templates/edx_supervisord.conf
+++ b/google-fluentd/templates/edx_supervisord.conf
@@ -1,0 +1,75 @@
+<source>
+  @type tail
+
+  # sample:
+  # 2019-03-07 12:41:47,480 WARNING 6019 [unlockerx.apps] apps.py:36 - Monkeypatching RateLimitMixin.requests to 100 for a bit more permissive limit.
+  format multiline
+  format_firstline /\d{4}-\d{1,2}-\d{1,2}/
+  format1 /^(?<time>\d{4}-\d{1,2}-\d{1,2} \d{1,2}:\d{1,2}:\d{1,2}),\d+ (?<level>[^\s]+) (?<pid>\d+) \[(?<thread>.*)\] (?<file>[^\:]+):(?<lineno>\d+) - (?<message>.*)/
+
+  path /edx/var/log/supervisor/lms*stderr.log
+  pos_file /var/lib/google-fluentd/pos/edx-supervisor-lms-stderr.pos
+  read_from_head true
+  tag edx-supervisor-lms-stderr
+</source>
+
+<source>
+  @type tail
+
+  # sample:
+  # 2019-03-07 12:41:47,480 WARNING 6019 [unlockerx.apps] apps.py:36 - Monkeypatching RateLimitMixin.requests to 100 for a bit more permissive limit.
+  format multiline
+  format_firstline /\d{4}-\d{1,2}-\d{1,2}/
+  format1 /^(?<time>\d{4}-\d{1,2}-\d{1,2} \d{1,2}:\d{1,2}:\d{1,2}),\d+ (?<level>[^\s]+) (?<pid>\d+) \[(?<thread>.*)\] (?<file>[^\:]+):(?<lineno>\d+) - (?<message>.*)/
+
+  path /edx/var/log/supervisor/cms*stderr.log
+  pos_file /var/lib/google-fluentd/pos/edx-supervisor-cms-stderr.pos
+  read_from_head true
+  tag edx-supervisor-cms-stderr
+</source>
+
+<source>
+  @type tail
+
+  # sample:
+  # W, [2019-03-07T17:41:56.322290 #6386]  WARN -- : Overwriting existing field _id in class User.
+  format multiline
+  format_firstline /\w\, \[/
+  format1 /^\w\, \[(?<time>\d{4}-\d{1,2}-\d{1,2}T\d{1,2}:\d{1,2}:\d{1,2}.\d+)\s+\#(?<pid>\d+)\]\s+(?<level>[^\s]+)\s+(?<message>.*)/
+
+  path /edx/var/log/supervisor/forum*stderr.log
+  pos_file /var/lib/google-fluentd/pos/edx-supervisor-forum-stderr.pos
+  read_from_head true
+  tag edx-supervisor-forum-stderr
+</source>
+
+<source>
+  @type tail
+
+  # sample:
+  # [2017-04-25 18:10:51 +0000 staging-amc-edxapp-ficus-0 (10726)] WARN : Agent is  configured to send raw SQL to the service
+  format multiline
+  format_firstline /\[\d{4}-\d{1,2}-\d{1,2}/
+  format1 /\[(?<time>\d{4}-\d{1,2}-\d{1,2}T\d{1,2}:\d{1,2}:\d{1,2}) \+\d+ \w+ \((?<pid>\d+)\)\]\s+(?<level>[^\s]+)\s+(?<message>.*)/
+
+  path /edx/var/log/supervisor/forum*stdout.log
+  pos_file /var/lib/google-fluentd/pos/edx-supervisor-forum-stdout.pos
+  read_from_head true
+  tag edx-supervisor-forum-stdout
+</source>
+
+
+<source>
+  @type tail
+
+  # sample:
+  # 2019-03-07 17:42:05,240 INFO success: certs entered RUNNING state, process has stayed up for > than 1 seconds (startsecs)
+  format multiline
+  format_firstline /\d{4}-\d{1,2}-\d{1,2}/
+  format1 /^(?<time>\d{4}-\d{1,2}-\d{1,2} \d{1,2}:\d{1,2}:\d{1,2}),\d+ (?<level>[^\s]+) (?<message>.*)/
+
+  path /edx/var/log/supervisor/supervisord.log
+  pos_file /var/lib/google-fluentd/pos/edx-supervisord.pos
+  read_from_head true
+  tag edx-supervisord
+</source>

--- a/google-fluentd/templates/edx_tracking.conf
+++ b/google-fluentd/templates/edx_tracking.conf
@@ -1,0 +1,11 @@
+
+<source>
+  @type tail
+  format json
+  time_key time
+  time_format "%iso8601"
+  path /edx/var/log/tracking/tracking.log
+  pos_file /var/lib/google-fluentd/pos/edx-tracking.pos
+  read_from_head true
+  tag edx-tracking
+</source>

--- a/google-fluentd/templates/kernlog.conf
+++ b/google-fluentd/templates/kernlog.conf
@@ -1,0 +1,11 @@
+<source>
+  @type tail
+
+  # Parse the timestamp, but still collect the entire line as 'message'
+  format /^(?<message>(?<time>[^ ]*\s*[^ ]* [^ ]*) .*)$/
+
+  path /var/log/kern.log
+  pos_file /var/lib/google-fluentd/pos/kernlog.pos
+  read_from_head true
+  tag kernlog
+</source>

--- a/google-fluentd/templates/letsencrypt.conf
+++ b/google-fluentd/templates/letsencrypt.conf
@@ -1,0 +1,15 @@
+<source>
+  @type tail
+
+  # sample:
+  # 2019-03-04 00:45:08,143:DEBUG:certbot.cli:Var post_hook=service nginx reload (set by user).
+  format multiline
+  format_firstline /\d{4}-\d{1,2}-\d{1,2}/
+  format1 /^(?<time>\d{4}-\d{1,2}-\d{1,2} \d{1,2}:\d{1,2}:\d{1,2}),\d+:(?<level>[^\s]+):(?<message>.*)/
+
+  path /var/log/letsencrypt/letsencrypt.log
+  pos_file /var/lib/google-fluentd/pos/letsencrypt.pos
+  read_from_head true
+  tag letsencrypt
+</source>
+


### PR DESCRIPTION
Trying to get config files for all of the common services we actually use to parse their custom log formats.

For this batch, I went through the logs on a ficus edxapp server. So this gets all the LMS/CMS logs, tracking logs, supervisord logs, plus some common ones like `auth.log`, `kern.log`, `apt/history.log`, and
letsencrypt logs.

Some of these could definitely be better as far as parsing out all of the fields. This first pass mostly just tries to get them all captured so we can do basic searching in stackdriver without worrying too much
about being able to precisely filter on every field.

The playbook deploying this role will need to specify which of these configs should be deployed and enabled with the `google_fluent_custom_config_files` and `google_fluent_custom_config_templates` settings.