### PR TITLE
avoid generating invalid letsencrypt nginx config

### DIFF
--- a/letsencrypt/templates/nginx/letsencrypt
+++ b/letsencrypt/templates/nginx/letsencrypt
@@ -7,7 +7,9 @@
 server {
     listen 80 {{ default_site }};
     listen [::]:80 {{ default_site }};
+{% if letsencrypt_certs|length > 0 %}
     server_name {{ letsencrypt_certs | sum(attribute='domains', start=[]) | join(' ') }};
+{% endif %}
 
     location '/.well-known/acme-challenge' {
         default_type "text/plain";

--- a/letsencrypt/templates/nginx/letsencrypt
+++ b/letsencrypt/templates/nginx/letsencrypt
@@ -7,7 +7,7 @@
 server {
     listen 80 {{ default_site }};
     listen [::]:80 {{ default_site }};
-{% if letsencrypt_certs|length > 0 %}
+{% if letsencrypt_certs %}
     server_name {{ letsencrypt_certs | sum(attribute='domains', start=[]) | join(' ') }};
 {% endif %}
 


### PR DESCRIPTION
if there are no letsencrypt_certs, it should skip setting the `server_name` altogether instead of producing a line like `server_name ;` which breaks nginx.

Normally, this shouldn't be an issue, but I've been running into it as I work on Tahoe Hawthorn, since I have to skip the custom domains role sometimes and that leaves the `letsencrypt` role with an empty `letsencrypt_certs` list and the bad nginx config, which I then have to manually delete after each deploy.