### PR TITLE
enable cert_agent systemd service on boot

### DIFF
--- a/cert_agent/tasks/main.yml
+++ b/cert_agent/tasks/main.yml
@@ -103,7 +103,7 @@
     - restart cert_agent
   tags: ['cert_agent', 'cert_agent:configuration']
 
-- name: Copy cert_agent systemd service
+- name: Copy cert_agent ssh private key
   become_user: "{{ cert_agent_app_user }}"
   copy:
       content={{ cert_agent_ssh_private_key }}

--- a/cert_agent/tasks/main.yml
+++ b/cert_agent/tasks/main.yml
@@ -112,3 +112,9 @@
       mode=600
   tags: ['cert_agent', 'cert_agent:configuration']
 
+- name: enable cert_agent systemd service on boot
+  systemd:
+    name: cert_agent.service
+    enabled: True
+    state: started
+  tags: ['cert_agent', 'cert_agent:configuration']


### PR DESCRIPTION
Enable it so it will be started automatically when the server boots. Also ensure that the service is started as part of the deploy.

(also fix a misleading task name that was next to it)