### PR TITLE
add role for fixing directory permissions

### DIFF
--- a/fix_dir_perms/defaults/main.yml
+++ b/fix_dir_perms/defaults/main.yml
@@ -1,0 +1,6 @@
+---
+
+fix_dir_perms_path: "/var/www"
+fix_dir_perms_owner: "www-data"
+fix_dir_perms_group: "www-data"
+fix_dir_perms_mode: "755"

--- a/fix_dir_perms/meta/main.yml
+++ b/fix_dir_perms/meta/main.yml
@@ -1,0 +1,3 @@
+---
+
+allow_duplicates: true

--- a/fix_dir_perms/tasks/main.yml
+++ b/fix_dir_perms/tasks/main.yml
@@ -1,0 +1,9 @@
+---
+
+- name: Fix directory permissions
+  file:
+    state: directory
+    path: "{{ fix_dir_perms_path }}"
+    owner: "{{ fix_dir_perms_owner }}"
+    group: "{{ fix_dir_perms_group }}"
+    mode: "{{ fix_dir_perms_mode }}"

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -15,3 +15,4 @@
     - stackdriver
     - sshguard
     - google-fluentd
+    - fix_dir_perms

--- a/tests/travis.yml
+++ b/tests/travis.yml
@@ -6,3 +6,4 @@
     - incron
     - sshguard
     - google-fluentd
+    - fix_dir_perms


### PR DESCRIPTION
Tahoe has a problem with conflicts between roles. `gcsfuse` creates `/var/www/letsencrypt`, which implicitly creates `/var/www` if it doesn't already exist. `nginx` creates `/var/www` but because we do other things in that role, in Tahoe's case it needs to run after gcsfuse. That leads to incorrect permissions/ownership on `/var/www`. We can't fix the ownership in the gcsfuse role because it runs potentially before nginx has created the user that it needs. The cleanest solution I could come up with (without completely refactoring our entire deployment) is to add a very simple utility role that we can run after both of them to fix up the permissions.