### PR TITLE
letsencrypt cleanup task

### DIFF
--- a/letsencrypt/defaults/main.yml
+++ b/letsencrypt/defaults/main.yml
@@ -30,3 +30,12 @@ letsencrypt_enable_default_server: false
 # letsencrypt_certs:
 #   - domains: ["foo.example.com", "bar.example.com"]
 #   - domains: ["baz.example.com"]
+
+# enables a cronjob that deletes old keys/csr files
+# those files are small and in 99.9% of deployments
+# will not consume enough disk space to be worth worrying about.
+# For very special cases like Tahoe, using a network filesystem
+# the per-file cost is high enough that we need to clean up
+# occasionally.
+letsencrypt_cleanup_enable: false
+letsencrypt_cleanup_days: 180

--- a/letsencrypt/tasks/main.yml
+++ b/letsencrypt/tasks/main.yml
@@ -225,3 +225,17 @@
       {{ letsencrypt_command }} renew --agree-tos --post-hook='service nginx reload'
   tags:
     - letsencrypt
+
+- name: Create a cleanup cronjob to clear old key and csr files
+  # see the description in defaults/main.yml
+  # only very rare situations (like Tahoe) will need this.
+  cron:
+    name: "letsencrypt disk cleanup"
+    cron_file: certbot_appsembler
+    special_time: daily
+    user: root
+    job: >
+      find /etc/letsencrypt/{keys,csr} -type f -mtime +{{ letsencrypt_cleanup_days }} -exec rm {} \;
+    when: letsencrypt_cleanup_enable
+    tags:
+    - letsencrypt


### PR DESCRIPTION
Cronjob to remove old certificate, key, and CSR files. Disabled by default.

Letsencrypt certificates are at most 90 days old. Any certificates, keys, or CSR files more than 90 days old are useless (and we default to only deleting after 180 days to be extra safe).

The files are very small and most of the time it isn't worth worrying about them. However, in Tahoe's case, since per-file access on the GCS Fuse mount is expensive, it matters at times. Specifically, tarring and untarring the `/etc/letsencrypt` directory for the ficus -> hawthorn upgrade touches every file in there. Checking on Tahoe staging, there are currently 1223 of these old files (more than 180 days old). It's about 1 second per file to read or write. That means that the process of making a tarball spends over 1200 seconds dealing with these files, and adds the same unpacking on the other side. So even though we don't *often* do it, deleting those old files first should save quite a bit of time whenever we do.