### PR TITLE
configure cert agent to use a dedicated playbook

### DIFF
--- a/cert_agent/defaults/main.yml
+++ b/cert_agent/defaults/main.yml
@@ -21,7 +21,7 @@ cert_agent_gunicorn_bind_ip: "0.0.0.0"
 cert_agent_gunicorn_port: "18000"
 cert_agent_gunicorn_timeout: "30"
 
-cert_agent_ansible_cmd: "cd /edx/app/edx_ansible/edx_ansible/playbooks && ../../venvs/edx_ansible/bin/ansible-playbook -i ../../app_nodes_inventory --extra-vars '@../../server-vars.yml' --tags=sudo,custom_domains,letsencrypt:run,nginx:custom_domains amc.yml"
+cert_agent_ansible_cmd: "cd /edx/app/edx_ansible/edx_ansible/playbooks && ../../venvs/edx_ansible/bin/ansible-playbook -i ../../app_nodes_inventory --extra-vars '@../../server-vars.yml' --tags=sudo,custom_domains,letsencrypt:run,nginx:custom_domains custom_domains.yml"
 
 cert_agent_statsd_host: 'stage-prometheus.infra.appsembler.com'
 cert_agent_statsd_port: 9125


### PR DESCRIPTION
The playbook it runs when adding a new custom domain. This is now dedicated (since it needs a slightly different order).

See: https://github.com/appsembler/configuration/pull/237 (it will need that one to be merged before this is safe to deploy)