### PR TITLE
monit is no longer used

### DIFF
--- a/tests/test.yml
+++ b/tests/test.yml
@@ -7,7 +7,6 @@
     - incron
     - letsencrypt
     - logstash
-    - monit
     - openjdk
     - ossec
     - sftp


### PR DESCRIPTION
not quite ready to delete the role (redeploying an old deployment may need it, but it will be safe once we have everything on hawthorn or later). But we might as well save a few seconds and skip it in the tests.