### PR TITLE
add scriabin role

### DIFF
--- a/scriabin/README.md
+++ b/scriabin/README.md
@@ -1,0 +1,14 @@
+scriabin is a stopgap script that watches our nginx logs and pushes
+the metrics to prometheus via a pushgateway.
+
+We would prefer a pull-based approach (see
+https://appsembler.atlassian.net/wiki/spaces/ED/pages/43614296/Getting+Data+into+Prometheus)
+but we don't have that set up yet.
+
+Scriabin works very simply by running once per minute in a cron
+job. It parses JSON formatted nginx logs (using Pygtail to track file
+offsets between runs) and submits the summarized metrics to
+Prometheus.
+
+This role should be installed on edxapp servers and, with a regular
+config, all the default values should work.

--- a/scriabin/defaults/main.yml
+++ b/scriabin/defaults/main.yml
@@ -1,0 +1,28 @@
+---
+
+scriabin_project: '{{ COMMON_DEPLOYMENT|default("project") }}-{{ COMMON_ENVIRONMENT|default("staging") }}'
+
+# we have `stage-pushgateway` and `pushgateway` setup, and we need to
+# map `staging` and `prod` to each of those respectively. This is the
+# best way I could figure out how to do it with just ansible/jinja2 filters:
+scriabin_prefix: "{{ COMMON_ENVIRONMENT|default('staging')|replace('prod', '')|replace('staging', 'stage-')}}"
+scriabin_pushgateway: "{{ scriabin_prefix }}pushgateway.infra.appsembler.com:9091"
+
+# requests that took longer than this many seconds are considered
+# "slow" for apdex calculation
+scriabin_slow_threshold: 0.4
+
+# don't include non-customer facing and static paths by default
+scriabin_ignore_paths: "/static/,/admin/,/hijack/,/favicon.ico"
+
+scriabin_logs_dir: /edx/var/log/nginx/
+
+scriabin_apps:
+  - "cms"
+  - "lms"
+
+scriabin_root: /opt/scriabin/
+scriabin_ve: "{{ scriabin_root }}ve"
+scriabin_python_version: python3
+scriabin_prometheus_client_version: 0.2.0
+scriabin_pygtail_version: 0.8.0

--- a/scriabin/files/scriabin.py
+++ b/scriabin/files/scriabin.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+import json
+import os
+import socket
+from datetime import datetime, timedelta
+from pygtail import Pygtail
+
+from prometheus_client import CollectorRegistry, push_to_gateway
+from prometheus_client import Gauge, Histogram
+
+# gather up environment variables
+
+LOG_FILE = os.environ.get("SCRIABIN_LOG_FILE",
+                          "/edx/var/log/nginx/access_json.log")
+SLOW_THRESHOLD = float(os.environ.get("SCRIABIN_SLOW_THRESHOLD",
+                                      "0.4"))  # seconds
+PROJECT = os.environ["SCRIABIN_PROJECT"]
+APP = os.environ["SCRIABIN_APP"]
+PUSHGATEWAY = os.environ.get("SCRIABIN_PUSHGATEWAY",
+                             'pushgateway.infra.appsembler.com:9091')
+SKIP_PATHS = os.environ.get(
+    "SCRIABIN_SKIP_PATHS",
+    "/static/,/admin/,/hijack/,/favicon.ico").split(",")
+TIME_FORMAT = os.environ.get("SCRIABIN_TIME_FORMAT",
+                             '%Y-%m-%dT%H:%M:%S+00:00')
+
+INSTANCE = socket.gethostname()
+OFFSET_FILE = "/tmp/scriabin-{}-{}.offset".format(PROJECT, APP)
+
+# prepare Prometheus metrics
+registry = CollectorRegistry()
+requests_counter = Gauge("nginx_requests", "HTTP Requests",
+                         ["status"],
+                         registry=registry)
+# make sure a few are always set, rather than have missing values
+requests_counter.labels(status=200).set(0)
+requests_counter.labels(status=201).set(0)
+requests_counter.labels(status=204).set(0)
+requests_counter.labels(status=206).set(0)
+requests_counter.labels(status=301).set(0)
+requests_counter.labels(status=302).set(0)
+requests_counter.labels(status=304).set(0)
+requests_counter.labels(status=400).set(0)
+requests_counter.labels(status=403).set(0)
+requests_counter.labels(status=404).set(0)
+requests_counter.labels(status=499).set(0)
+requests_counter.labels(status=500).set(0)
+requests_counter.labels(status=502).set(0)
+
+response_time = Histogram("nginx_response_time", "HTTP Response Time (s)",
+                          buckets=[.01, 0.02, 0.04, 0.1, 0.2, 0.4, 1.0,
+                                   2.0, 4.0, 10.0, 20.0, 40.0,
+                                   float("inf")],
+                          registry=registry)
+
+apdex_score = Gauge("apdex_score", "Apdex", registry=registry)
+parse_errors = Gauge("parse_errors", "Nginx log parse errors",
+                     registry=registry)
+
+
+def log_entries(now=None, window_minutes=1):
+    """ returns the log entries that we are interested in
+
+    ie, within our time window, and not in the skip list """
+    if now is None:
+        now = datetime.utcnow()
+    start = now - timedelta(minutes=window_minutes)
+    errors = 0
+    entries = []
+    for line in Pygtail(LOG_FILE, offset_file=OFFSET_FILE):
+        try:
+            d = json.loads(line)
+            ts = datetime.strptime(d['time_local'], TIME_FORMAT)
+            if ts < start:
+                # ignore entries that are too old
+                # with pygtail, this should mostly only happen on the first run
+                continue
+            entries.append(d)
+        except Exception as e:
+            print(e)
+            errors += 1
+    return entries, errors
+
+
+def main():
+    total_requests = 0
+    failed_requests = 0
+    slow_requests = 0
+
+    entries, errors = log_entries()
+    for d in entries:
+        total_requests += 1
+        requests_counter.labels(status=d['status']).inc()
+        if d['status'].startswith('5'):
+            failed_requests += 1
+        rt = float(d['request_time'])
+        response_time.observe(rt)
+        if rt > SLOW_THRESHOLD:
+            slow_requests += 1
+
+    apdex_score.set(1)
+    if total_requests > 0:
+        satisfied = total_requests - (failed_requests + slow_requests)
+        apdex_score.set((satisfied + (slow_requests / 2)) / total_requests)
+
+    parse_errors.set(errors)
+
+    print("total_requests:", total_requests)
+    print("failed:", failed_requests)
+    print("slow:", slow_requests)
+
+    push_to_gateway(PUSHGATEWAY, job="{}_{}_nginx".format(PROJECT, APP),
+                    registry=registry, grouping_key={'instance': INSTANCE})
+
+
+if __name__ == "__main__":
+    main()

--- a/scriabin/tasks/main.yml
+++ b/scriabin/tasks/main.yml
@@ -1,0 +1,35 @@
+---
+
+- name: install certain python modules for scriabin
+  pip:
+    name: "{{ item.name }}"
+    version: "{{ item.version }}"
+    virtualenv: "{{ scriabin_ve }}"
+    virtualenv_python: "{{ scriabin_python_version }}"
+    state: present
+  with_items:
+    - {name: prometheus_client, version: "{{ scriabin_prometheus_client_version }}"}
+    - {name: pygtail, version: "{{ scriabin_pygtail_version }}"}
+  tags: ['scriabin', 'scriabin:install']
+
+- name: Copy script
+  copy:
+    src: scriabin.py
+    dest: "{{ scriabin_root }}scriabin"
+    owner: www-data
+    mode: 0755
+  tags: ['scriabin', 'scriabin:install']
+
+- name: Full script
+  template:
+    src: run_scriabin.sh.j2
+    dest: "{{ scriabin_root }}run_scriabin.sh"
+    mode: 0775
+  tags: ['scriabin', 'scriabin:install']
+
+- name: Create cron job for Scriabin
+  cron:
+    name: "Scriabin"
+    user: www-data
+    job: "{{ scriabin_root }}run_scriabin.sh"
+  tags: ['scriabin', 'scriabin:install']

--- a/scriabin/templates/run_scriabin.sh.j2
+++ b/scriabin/templates/run_scriabin.sh.j2
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+export SCRIABIN_PROJECT="{{ scriabin_project }}"
+export SCRIABIN_SLOW_THRESHOLD="{{ scriabin_slow_threshold }}"
+export SCRIABIN_PUSHGATEWAY="{{ scriabin_pushgateway }}"
+export SCRIABIN_SKIP_PATHS="{{ scriabin_ignore_paths }}"
+
+{% for app in scriabin_apps %}
+export SCRIABIN_LOG_FILE="{{ scriabin_logs_dir }}access_{{ app }}_json.log"
+export SCRIABIN_APP="{{ app }}"
+{{ scriabin_ve }}/bin/python3 {{ scriabin_root }}scriabin
+{% endfor %}

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -15,3 +15,4 @@
     - sshguard
     - google-fluentd
     - fix_dir_perms
+    - scriabin

--- a/tests/travis.yml
+++ b/tests/travis.yml
@@ -7,3 +7,4 @@
     - sshguard
     - google-fluentd
     - fix_dir_perms
+    - scriabin

--- a/travis/Dockerfile.ubuntu-bionic
+++ b/travis/Dockerfile.ubuntu-bionic
@@ -5,6 +5,7 @@ RUN apt-get update && apt-get dist-upgrade -y && apt-get install -y software-pro
 RUN apt-get update && apt-get install -y \
     git \
     init \
+    python3 \
     python-dev \
     python-pip \
     python-virtualenv \


### PR DESCRIPTION
https://appsembler.atlassian.net/browse/OT-293

scriabin is a stopgap script that watches our nginx logs and pushes the metrics to prometheus via a pushgateway.

We would prefer a pull-based approach (see
https://appsembler.atlassian.net/wiki/spaces/ED/pages/43614296/Getting+Data+into+P
rometheus) but we don't have that set up yet.

Scriabin works very simply by running once per minute in a cron job. It parses JSON formatted nginx logs (using Pygtail to track file offsets between runs) and submits the summarized metrics to
Prometheus.

This role should be installed on edxapp servers and, with a regular config, all the default values should work.

The code for this role is taken almost directly from `infrastructure`, where it was created and where it's been used for Tahoe, etc. for a while now. This just moves it to `roles` so we can add it to the rest
of our playbooks.