### PR TITLE
Test on bionic

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,9 @@ sudo: required
 
 env:
   - distribution: ubuntu
+    version: bionic
+    ansible: 2.4.3.0
+  - distribution: ubuntu
     version: xenial
     ansible: 2.4.3.0
   - distribution: ubuntu

--- a/gcsfuse/tasks/main.yml
+++ b/gcsfuse/tasks/main.yml
@@ -1,11 +1,11 @@
 ---
 
-- name: Add gcsfuse repo
-  apt_repository: repo="{{ gcsfuse_repo }}"
-  tags: ['gcsfuse', 'gcsfuse:install']
-
 - name: Add repository key
   apt_key: url="{{ gcsfuse_apt_key_url }}"
+  tags: ['gcsfuse', 'gcsfuse:install']
+
+- name: Add gcsfuse repo
+  apt_repository: repo="{{ gcsfuse_repo }}"
   tags: ['gcsfuse', 'gcsfuse:install']
 
 - name: Install gcsfuse

--- a/travis/Dockerfile.ubuntu-bionic
+++ b/travis/Dockerfile.ubuntu-bionic
@@ -4,10 +4,10 @@ RUN apt-get update && apt-get dist-upgrade -y && apt-get install -y software-pro
 
 RUN apt-get update && apt-get install -y \
     git \
+    init \
     python-dev \
     python-pip \
     python-virtualenv \
-    init \
  && rm -rf /var/lib/apt/lists/*
 
 ARG ansible_version=2.4.3.0

--- a/travis/Dockerfile.ubuntu-bionic
+++ b/travis/Dockerfile.ubuntu-bionic
@@ -1,0 +1,19 @@
+FROM ubuntu:bionic
+
+RUN apt-get update && apt-get dist-upgrade -y && apt-get install -y software-properties-common && rm -rf /var/lib/apt/lists/*
+
+RUN apt-get update && apt-get install -y \
+    git \
+    python-dev \
+    python-pip \
+    python-virtualenv \
+    init \
+ && rm -rf /var/lib/apt/lists/*
+
+ARG ansible_version=2.4.3.0
+
+RUN pip install ansible==${ansible_version}
+RUN mkdir /etc/ansible/
+RUN echo "[local]\nlocalhost ansible_connection=local" > /etc/ansible/hosts
+
+ENTRYPOINT ["/sbin/init"]


### PR DESCRIPTION
Since we dropped Trusty, I figured it's about time we start thinking about the future. This adds 18.04 to our tests (only with the newer ansible release though since any new 18.04 based systems we set up we ought to be able to restrict to newer ansible releases; ansible 2.3 will be the next thing to work on phasing out).

Of the existing roles, it did uncover one issue with `gcsfuse`, which is that it was installing the APT repo before installing the key for that repo. I think on older releases, nothing was actually verified until you actually did an `apt-get install` but from 18.04 forward, it checks the key when you add the repo, so those steps needed to be reversed in the playbook.