### PR TITLE
fix certbot version pin

### DIFF
--- a/letsencrypt/defaults/main.yml
+++ b/letsencrypt/defaults/main.yml
@@ -5,7 +5,7 @@
 # Note: The trailing `-*` is to match the rather verbose package
 #       versions in Debian e.g. `0.22.2-1+ubuntu16.04.1+certbot+1`
 letsencrypt_package: "certbot={{ letsencrypt_version }}-*"
-letsencrypt_version: "0.31.0"
+letsencrypt_version: "0.31.0-1+ubuntu16.04.1+certbot+1"
 
 letsencrypt_command: "certbot"
 letsencrypt_certbot_plugin: "webroot"


### PR DESCRIPTION
The version `0.31.0` wasn't being found on the ubuntu apt.
```
Reading package lists... Done
Building dependency tree       
Reading state information... Done
E: Version '0.31.0' for 'certbot' was not found
```
It's named `0.31.0-1+ubuntu16.04.1+certbot+1`.