### PR TITLE
include COMMON_RELEASE in scriabin project identifier

### DIFF
--- a/scriabin/defaults/main.yml
+++ b/scriabin/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 
-scriabin_project: '{{ COMMON_DEPLOYMENT|default("project") }}-{{ COMMON_ENVIRONMENT|default("staging") }}'
+scriabin_project: '{{ COMMON_DEPLOYMENT|default("project") }}-{{ COMMON_RELEASE|default("release")}}-{{ COMMON_ENVIRONMENT|default("staging") }}'
 
 # we have `stage-pushgateway` and `pushgateway` setup, and we need to
 # map `staging` and `prod` to each of those respectively. This is the


### PR DESCRIPTION
Realizing that we will need this so there aren't conflicts between eg, the ginkgo/ficus version and hawthorn version while we are working on the latter and have both running.

Eg, currently UW metrics are going to Prometheus as `uw-prod`. This would change it to `uw-hawthorn-prod`.