### PR TITLE
add honeycomb config to cert_agent

### DIFF
--- a/cert_agent/defaults/main.yml
+++ b/cert_agent/defaults/main.yml
@@ -28,6 +28,9 @@ cert_agent_statsd_host: 'stage-prometheus.infra.appsembler.com'
 cert_agent_statsd_port: 9125
 cert_agent_statsd_prefix: 'tahoe_cert_agent'
 
+cert_agent_honeycomb_dataset: "changeme"
+cert_agent_honeycomb_writekey: "changeme"
+
 cert_agent_django_env_vars: {
   API_SECRET_KEY: "{{cert_agent_api_secret_key}}",
   DJANGO_DEBUG: "{{cert_agent_django_debug}}",
@@ -40,6 +43,8 @@ cert_agent_django_env_vars: {
   STATSD_HOST: "{{ cert_agent_statsd_host }}",
   STATSD_PORT: "{{ cert_agent_statsd_port }}",
   STATSD_PREFIX: "{{ cert_agent_statsd_prefix }}",
+  HONEYCOMB_DATASET: "{{ cert_agent_honeycomb_dataset }}",
+  HONEYCOMB_WRITEKEY: "{{ cert_agent_honeycomb_writekey }}",
 }
 
 cert_agent_ssh_private_key: "changeme"

--- a/cert_agent/defaults/main.yml
+++ b/cert_agent/defaults/main.yml
@@ -28,8 +28,8 @@ cert_agent_statsd_host: 'stage-prometheus.infra.appsembler.com'
 cert_agent_statsd_port: 9125
 cert_agent_statsd_prefix: 'tahoe_cert_agent'
 
-cert_agent_honeycomb_dataset: "changeme"
-cert_agent_honeycomb_writekey: "changeme"
+cert_agent_honeycomb_dataset: !!null
+cert_agent_honeycomb_writekey: !!null
 
 cert_agent_django_env_vars: {
   API_SECRET_KEY: "{{cert_agent_api_secret_key}}",

--- a/cert_agent/templates/cert_agent.service
+++ b/cert_agent/templates/cert_agent.service
@@ -8,7 +8,9 @@ User={{ cert_agent_app_user }}
 Group={{ cert_agent_app_user }}
 WorkingDirectory={{ cert_agent_django_project_dir }}
 RuntimeDirectory={{ cert_agent_gunicorn_runtime_dir_name }}
-ExecStart={{ cert_agent_venv_dir }}/bin/gunicorn --pid {{ cert_agent_gunicorn_pid }} \
+ExecStart={{ cert_agent_venv_dir }}/bin/gunicorn \
+          -c {{ cert_agent_django_project_dir }}/cert_agent/gunicorn_conf.py \
+          --pid {{ cert_agent_gunicorn_pid }} \
           --bind {{ cert_agent_gunicorn_bind_ip }}:{{ cert_agent_gunicorn_port }} \
           -w 3 \
           cert_agent.wsgi:application \


### PR DESCRIPTION
adds dataset and writekey vars to the environment and adds tells gunicorn to point at the config that loads the `post_worker_init()` hook.

This of course will require https://github.com/appsembler/tahoe_cert_agent/pull/15