### PR TITLE
run cert_agent with python3

### DIFF
--- a/cert_agent/tasks/main.yml
+++ b/cert_agent/tasks/main.yml
@@ -35,7 +35,7 @@
     requirements='requirements.txt'
     virtualenv={{cert_agent_venv_dir}}
     chdir={{cert_agent_git_repo_dir}}
-    virtualenv_python=python2.7
+    virtualenv_python=python3
   tags: ['cert_agent', 'cert_agent:requirements']
 
 - name: Set up virtualenv postactivate scripts


### PR DESCRIPTION
pre-requisite for upgrading to Django 2.0.

We already test against python3: https://github.com/appsembler/tahoe_cert_agent/blob/master/tox.ini#L2 so it *should* be fine.