### PR TITLE
move letsencrypt cleanup to a dedicated script

### DIFF
--- a/letsencrypt/tasks/main.yml
+++ b/letsencrypt/tasks/main.yml
@@ -241,16 +241,25 @@
   tags:
     - letsencrypt
 
-- name: Create a cleanup cronjob to clear old key and csr files
+- name: Create cleanup script to clear old files
   # see the description in defaults/main.yml
   # only very rare situations (like Tahoe) will need this.
+  template:
+    src: opt/scripts/le_cleanup.sh.j2
+    dest: /opt/scripts/le_cleanup.sh
+    mode: 0744
+  when: letsencrypt_cleanup_enable
+  tags:
+    - letsencrypt
+
+- name: Cronjob to run the cleanup script nightly
   cron:
     name: "letsencrypt disk cleanup"
     cron_file: certbot_appsembler
     special_time: daily
     user: root
     job: >
-      find /etc/letsencrypt/{keys,csr} -type f -mtime +{{ letsencrypt_cleanup_days }} -exec rm {} \;
+      /opt/scripts/le_cleanup.sh
   when: letsencrypt_cleanup_enable
   tags:
     - letsencrypt

--- a/letsencrypt/templates/opt/scripts/le_cleanup.sh
+++ b/letsencrypt/templates/opt/scripts/le_cleanup.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# remove old keys/csr files
+find /etc/letsencrypt/{keys,csr} -type f -mtime +{{ letsencrypt_cleanup_days }} -exec rm {} \;
+
+# remove the old HTTP-01 challenge files
+find /var/www/letsencrypt/acme-challenges-custom-folder/ -type f -mtime +{{ letsencrypt_cleanup_days }} -exec rm {} \;
+


### PR DESCRIPTION
the inline command in the cronjob was failing because cron doesn't understand bash syntax.

So we move it out to a dedicated script where we can make sure that it is run with `/bin/bash`.

Also clear out the HTTP-01 challenge files while we are at it (since those can also potentially blow the GCS fuse stat cache)