### PR TITLE
pin bcrypt version for xenial on TravisCI

### DIFF
--- a/travis/Dockerfile.ubuntu-xenial
+++ b/travis/Dockerfile.ubuntu-xenial
@@ -11,7 +11,7 @@ RUN apt-get update && apt-get install -y \
  
 ARG ansible_version=2.4.3.0
 
-RUN pip install ansible==${ansible_version}
+RUN pip install bcrypt==3.1.7 ansible==${ansible_version}
 RUN mkdir /etc/ansible/
 RUN echo "[local]\nlocalhost ansible_connection=local" > /etc/ansible/hosts
 


### PR DESCRIPTION
TravisCI xenial builds started failing because a new version of bcrypt was released on Aug 16th that breaks things.

This pins the bcrypt version to the version previous to that release.