### PR TITLE
scriabin: write metrics to node_exporter text collector dir

### DIFF
--- a/scriabin/files/scriabin.py
+++ b/scriabin/files/scriabin.py
@@ -6,7 +6,7 @@ from datetime import datetime, timedelta
 from dateutil import parser, tz
 from pygtail import Pygtail
 
-from prometheus_client import CollectorRegistry, push_to_gateway
+from prometheus_client import CollectorRegistry, push_to_gateway, write_to_textfile
 from prometheus_client import Gauge, Histogram
 
 # gather up environment variables
@@ -110,6 +110,7 @@ def main():
 
     push_to_gateway(PUSHGATEWAY, job="{}_{}_nginx".format(PROJECT, APP),
                     registry=registry, grouping_key={'instance': INSTANCE})
+    write_to_textfile("/var/lib/node_exporter/nginx.prom", registry)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
now that we have node_exporter installed (at least everywhere that scriabin is installed), we ought to be able to rely on it for exporting metrics instead of going through the pushgateway.

This adds a little bit of code to do that.

For now, we leave in the pushgateway parts so it's actually exporting metrics both ways. This gives us some overlap so we can let the new metrics (collected via node_exporter) populate, then update our Grafana graphs to use them. Then we can remove the old pushgateway code once those metrics are no longer being used.