### PR TITLE
remove nonempty option from gcsfuse mount

### DIFF
--- a/gcsfuse/tasks/main.yml
+++ b/gcsfuse/tasks/main.yml
@@ -42,7 +42,7 @@
   tags: ['gcsfuse', 'gcsfuse:configuration']
 
 - name: Mount buckets in directories
-  shell: gcsfuse {{ (item.allow_other|default(false)) | ternary("-o allow_other", "") }}  -o allow_other {{ (item.keyfile != None) | ternary("--key-file " + item.keyfile, "") }} -o nonempty "{{ item.bucket }}" "{{ item.path }}" && touch "{{ item.path }}/.mounted"
+  shell: gcsfuse {{ (item.allow_other|default(false)) | ternary("-o allow_other", "") }}  -o allow_other {{ (item.keyfile != None) | ternary("--key-file " + item.keyfile, "") }} "{{ item.bucket }}" "{{ item.path }}" && touch "{{ item.path }}/.mounted"
   args:
     creates: "{{ item.path }}/.mounted"
   become: true
@@ -55,7 +55,7 @@
     name: "Mount bucket `{{ item.bucket }}` at `{{ item.path }}`"
     cron_file: "gcsfuse"
     special_time: "reboot"
-    job: gcsfuse {{ (item.allow_other|default(false)) | ternary("-o allow_other", "") }} {{ (item.keyfile != None) | ternary("--key-file " + item.keyfile, "") }} -o nonempty "{{ item.bucket }}" "{{ item.path }}" && touch "{{ item.path }}/.mounted"
+    job: gcsfuse {{ (item.allow_other|default(false)) | ternary("-o allow_other", "") }} {{ (item.keyfile != None) | ternary("--key-file " + item.keyfile, "") }} "{{ item.bucket }}" "{{ item.path }}" && touch "{{ item.path }}/.mounted"
     user: "{{ item.owner | default('root') }}"
   with_items: "{{ gcsfuse_mounts }}"
   tags: ['gcsfuse', 'gcsfuse:configuration']

--- a/tests/travis.yml
+++ b/tests/travis.yml
@@ -6,6 +6,5 @@
     - incron
     - node_exporter
     - sshguard
-    - google-fluentd
     - fix_dir_perms
     - scriabin


### PR DESCRIPTION
no longer supported in current versions of gcsfuse. See: https://github.com/GoogleCloudPlatform/gcsfuse/issues/424

Running into this on Juniper. We'll also hit it if we have to deploy new servers for Tahoe hawthorn since we don't pin the version and a freshly provisioned server would get the newer gcsfuse and break.

`-o nonempty` just tells it that it's OK to mount a directory even if data already exists in that directory. That *shouldn't* occur anyway in our regular case. If we find that we're trying to mount a non-empty directory, that probably indicates a bug elsewhere in our setup that should be investigated and fixed rather than papered over with this.