### PR TITLE
cert_agent role ssh private key copy fails w/o first making .ssh dir

### DIFF
--- a/cert_agent/tasks/main.yml
+++ b/cert_agent/tasks/main.yml
@@ -108,6 +108,14 @@
     - restart cert_agent
   tags: ['cert_agent', 'cert_agent:configuration']
 
+- name: Create cert_agent .ssh directory
+  become_user: "{{ cert_agent_app_user }}"
+  file:
+    path: "/home/{{ cert_agent_app_user }}/.ssh"
+    state: directory
+    owner: "{{ cert_agent_app_user }}"
+  tags: ['cert_agent', 'cert_agent:configuration']
+
 - name: Copy cert_agent ssh private key
   become_user: "{{ cert_agent_app_user }}"
   copy:


### PR DESCRIPTION
copy with a file doesn't automatically make intermediate dirs